### PR TITLE
[C-01, 5.1] Univ3twap

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -20,6 +20,9 @@ remappings = [
     'forge-std/=lib/forge-std/src/'
 ]
 
+[profile.ci]
+# inherit the default by creating an empty CI profiile
+
 [fuzz]
 runs = 1000
 

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -236,6 +236,9 @@ contract ForeignController is AccessControl {
 
     function setUniswapV3TwapSecondsAgo(address pool, uint32 twapSecondsAgo) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
+        // Required due to casting in UniswapV3OracleLibrary.consult
+        // Limits twapSecondsAgo to approximately 68 years
+        require(twapSecondsAgo < uint32(type(int32).max), "ForeignController/twap-seconds-ago-out-of-bounds");
         params.twapSecondsAgo = twapSecondsAgo;
         emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -215,7 +215,7 @@ contract ForeignController is AccessControl {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
         params.swapMaxTickDelta = maxTickDelta;
         emit UniswapV3PoolMaxTickDeltaSet(pool, maxTickDelta);
-    }   
+    }
 
     function setUniswapV3AddLiquidityLowerTickBound(address pool, int24 lowerTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
@@ -872,7 +872,8 @@ contract ForeignController is AccessControl {
                 min             : min,
                 tickBounds      : poolParams.addLiquidityTickBounds,
                 maxSlippage     : maxSlippage,
-                deadline        : deadline
+                deadline        : deadline,
+                twapSecondsAgo  : poolParams.twapSecondsAgo
             })
         );
     }

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -65,6 +65,7 @@ contract ForeignController is AccessControl {
     event UniswapV3PoolLowerTickUpdated(address indexed pool, int24 lowerTick);
     event UniswapV3PoolUpperTickUpdated(address indexed pool, int24 upperTick);
     event UniswapV3PoolMaxTickDeltaSet(address indexed pool, uint24 maxTickDelta);
+    event UniswapV3PoolTwapSecondsAgoUpdated(address indexed pool, uint32 twapSecondsAgo);
 
     /**********************************************************************************************/
     /*** State variables                                                                        ***/
@@ -231,6 +232,12 @@ contract ForeignController is AccessControl {
 
         params.addLiquidityTickBounds.upper = upperTickBound;
         emit UniswapV3PoolUpperTickUpdated(pool, upperTickBound);
+    }
+
+    function setUniswapV3TwapSecondsAgo(address pool, uint32 twapSecondsAgo) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
+        params.twapSecondsAgo = twapSecondsAgo;
+        emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }
 
     function setMerklDistributor(address merklDistributor_)

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -71,6 +71,7 @@ contract MainnetController is AccessControl {
     event UniswapV3PoolMaxTickDeltaSet(address indexed pool, uint24 maxTickDelta);
     event UniswapV3PoolLowerTickUpdated(address indexed pool, int24 lowerTick);
     event UniswapV3PoolUpperTickUpdated(address indexed pool, int24 upperTick);
+    event UniswapV3PoolTwapSecondsAgoUpdated(address indexed pool, uint32 twapSecondsAgo);
 
     /**********************************************************************************************/
     /*** State variables                                                                        ***/
@@ -230,6 +231,12 @@ contract MainnetController is AccessControl {
 
         params.addLiquidityTickBounds.upper = upperTickBound;
         emit UniswapV3PoolUpperTickUpdated(pool, upperTickBound);
+    }
+
+    function setUniswapV3TwapSecondsAgo(address pool, uint32 twapSecondsAgo) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
+        params.twapSecondsAgo = twapSecondsAgo;
+        emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }
 
     function setCentrifugeRecipient(uint16 centrifugeId, bytes32 recipient) external {

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -235,6 +235,9 @@ contract MainnetController is AccessControl {
 
     function setUniswapV3TwapSecondsAgo(address pool, uint32 twapSecondsAgo) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
+        // Required due to casting in UniswapV3OracleLibrary.consult
+        // Limits twapSecondsAgo to approximately 68 years
+        require(twapSecondsAgo < uint32(type(int32).max), "MainnetController/twap-seconds-ago-out-of-bounds");
         params.twapSecondsAgo = twapSecondsAgo;
         emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -582,7 +582,7 @@ contract MainnetController is AccessControl {
             maxSlippage        : maxSlippages[pool]
         }));
     }
-    
+
     /**********************************************************************************************/
     /*** Relayer UniswapV3 functions                                                            ***/
     /**********************************************************************************************/
@@ -647,7 +647,8 @@ contract MainnetController is AccessControl {
                 min             : min,
                 tickBounds      : poolParams.addLiquidityTickBounds,
                 maxSlippage     : maxSlippage,
-                deadline        : deadline
+                deadline        : deadline,
+                twapSecondsAgo  : poolParams.twapSecondsAgo
             })
         );
     }

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -81,7 +81,6 @@ library UniswapV3Lib {
         uint256                     deadline;
     }
 
-
     /**********************************************************************************************/
     /*** External functions                                                                     ***/
     /**********************************************************************************************/
@@ -128,12 +127,7 @@ library UniswapV3Lib {
         ERC20Lib.approve(context.proxy, token0, address(params.positionManager), params.target.amount0);
         ERC20Lib.approve(context.proxy, token1, address(params.positionManager), params.target.amount1);
 
-        _validateMinAmountsTwap(context, TwapParams({
-            twapSecondsAgo : params.twapSecondsAgo,
-            tick           : params.tick,
-            target         : params.target,
-            min            : params.min
-        }));
+        _validateAddLiquidityMinAmounts(context, params);
 
         uint256 startingBalance0 = IERC20(token0).balanceOf(address(context.proxy));
         uint256 startingBalance1 = IERC20(token1).balanceOf(address(context.proxy));
@@ -231,17 +225,17 @@ library UniswapV3Lib {
             "UniswapV3Lib/invalid-token-pair"
         );
 
-        // Fetch twap tick as the current tick
-        (int24 currentTick, ) = UniswapV3OracleLib.consult(context.pool, params.poolParams.twapSecondsAgo);
+        // Fetch twap tick
+        (int24 twapTick, ) = UniswapV3OracleLib.consult(context.pool, params.poolParams.twapSecondsAgo);
 
         cache.tokenOut = params.tokenIn == token0 ? token1 : token0;
 
         int24 delta = int24(params.tickDelta);
         int24 limitTick;
         if (params.tokenIn == token0) {
-            limitTick = MathLib._max(currentTick - delta, TickMath.MIN_TICK);
+            limitTick = MathLib._max(twapTick - delta, TickMath.MIN_TICK);
         } else {
-            limitTick = MathLib._min(currentTick + delta, TickMath.MAX_TICK);
+            limitTick = MathLib._min(twapTick + delta, TickMath.MAX_TICK);
         }
 
         cache.sqrtPriceLimitX96 = TickMath.getSqrtRatioAtTick(limitTick);
@@ -392,7 +386,7 @@ library UniswapV3Lib {
         }
     }
 
-    function _validateMinAmountsTwap(UniV3Context calldata context, TwapParams calldata params) internal view {
+    function _validateAddLiquidityMinAmounts(UniV3Context calldata context, AddLiquidityParams calldata params) internal view {
         // Fetch twap tick
         (int24 twapTick, ) = UniswapV3OracleLib.consult(context.pool, params.twapSecondsAgo);
 

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -81,6 +81,14 @@ library UniswapV3Lib {
         uint256                     deadline;
     }
 
+    struct TwapParams {
+        uint32       twapSecondsAgo;
+        Tick         tick;
+        TokenAmounts target;
+        TokenAmounts min;
+
+    }
+
     /**********************************************************************************************/
     /*** External functions                                                                     ***/
     /**********************************************************************************************/
@@ -91,6 +99,14 @@ library UniswapV3Lib {
 
         require(params.maxSlippage > 0,                                 "UniswapV3Lib/max-slippage-not-set");
         require(params.tickDelta <= params.poolParams.swapMaxTickDelta, "UniswapV3Lib/invalid-max-tick-delta");
+        require(params.twapSecondsAgo != 0,                             "UniswapV3Lib/zero-twap-seconds");
+
+        _validateMinAmountsTwap(context, TwapParams({
+            twapSecondsAgo : params.twapSecondsAgo,
+            tick           : params.tick,
+            target         : params.target,
+            min            : params.min
+        }));
 
         context.rateLimits.triggerRateLimitDecrease(
             RateLimitHelpers.makeAssetDestinationKey(context.rateLimitId, params.tokenIn, context.pool),
@@ -126,7 +142,12 @@ library UniswapV3Lib {
         ERC20Lib.approve(context.proxy, token0, address(params.positionManager), params.target.amount0);
         ERC20Lib.approve(context.proxy, token1, address(params.positionManager), params.target.amount1);
 
-        _validateAddLiquidityMinAmounts(context, params);
+        _validateMinAmountsTwap(context, TwapParams({
+            twapSecondsAgo : params.twapSecondsAgo,
+            tick           : params.tick,
+            target         : params.target,
+            min            : params.min
+        }));
 
         uint256 startingBalance0 = IERC20(token0).balanceOf(address(context.proxy));
         uint256 startingBalance1 = IERC20(token1).balanceOf(address(context.proxy));
@@ -384,7 +405,7 @@ library UniswapV3Lib {
         }
     }
 
-    function _validateAddLiquidityMinAmounts(UniV3Context calldata context, AddLiquidityParams calldata params) internal view {
+    function _validateMinAmountsTwap(UniV3Context calldata context, TwapParams calldata params) internal view {
         // Fetch twap tick
         (int24 twapTick, ) = UniswapV3OracleLib.consult(context.pool, params.twapSecondsAgo);
 

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -417,7 +417,6 @@ library UniswapV3Lib {
                 expectedLiquidity,
                 false
             );
-
         } else {
             expectedAmount0 = UniV3UtilsLib.getAmount0Delta(
                 sqrtTwapPriceX96,
@@ -439,6 +438,10 @@ library UniswapV3Lib {
     }
 
     function _validateMinAmount(uint256 minAmount, uint256 expectedAmount, uint256 maxSlippage) internal pure {
+        if (expectedAmount == 0) {
+            require(minAmount == 0, "UniswapV3Lib/min-amount-below-bound");
+            return;
+        }
         uint256 minAmountThreshold = FullMath.mulDiv(expectedAmount, maxSlippage, 1e18);
         require(minAmount >= minAmountThreshold, "UniswapV3Lib/min-amount-below-bound");
     }

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -81,6 +81,7 @@ library UniswapV3Lib {
         uint256                     deadline;
     }
 
+<<<<<<< HEAD
     struct TwapParams {
         uint32       twapSecondsAgo;
         Tick         tick;
@@ -88,6 +89,8 @@ library UniswapV3Lib {
         TokenAmounts min;
 
     }
+=======
+>>>>>>> 0600a3c (use twap tick for swap)
 
     /**********************************************************************************************/
     /*** External functions                                                                     ***/
@@ -95,10 +98,9 @@ library UniswapV3Lib {
 
     // Rate limit decreased by value of token1
     function swap(UniV3Context calldata context, SwapParams calldata params) external returns (uint256 amountOut) {
-        SwapCache memory cache = _populateSwapCache(context, params);
-
         require(params.maxSlippage > 0,                                 "UniswapV3Lib/max-slippage-not-set");
         require(params.tickDelta <= params.poolParams.swapMaxTickDelta, "UniswapV3Lib/invalid-max-tick-delta");
+<<<<<<< HEAD
         require(params.twapSecondsAgo != 0,                             "UniswapV3Lib/zero-twap-seconds");
 
         _validateMinAmountsTwap(context, TwapParams({
@@ -107,6 +109,11 @@ library UniswapV3Lib {
             target         : params.target,
             min            : params.min
         }));
+=======
+        require(params.poolParams.twapSecondsAgo != 0,                  "UniswapV3Lib/zero-twap-seconds");
+
+        SwapCache memory cache = _populateSwapCache(context, params);
+>>>>>>> 0600a3c (use twap tick for swap)
 
         context.rateLimits.triggerRateLimitDecrease(
             RateLimitHelpers.makeAssetDestinationKey(context.rateLimitId, params.tokenIn, context.pool),
@@ -245,7 +252,8 @@ library UniswapV3Lib {
             "UniswapV3Lib/invalid-token-pair"
         );
 
-        (, int24 currentTick, , , , , ) = pool.slot0();
+        // Fetch twap tick as the current tick
+        (int24 currentTick, ) = UniswapV3OracleLib.consult(context.pool, params.poolParams.twapSecondsAgo);
 
         cache.tokenOut = params.tokenIn == token0 ? token1 : token0;
 

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -410,8 +410,6 @@ library UniswapV3Lib {
                 expectedLiquidity,
                 false
             );
-
-            _validateMinAmount(params.min.amount0, expectedAmount0, params.maxSlippage);
         } else if (twapTick >= params.tick.upper) {
             expectedAmount1 = UniV3UtilsLib.getAmount1Delta(
                 sqrtRatioLowerX96,
@@ -420,7 +418,6 @@ library UniswapV3Lib {
                 false
             );
 
-            _validateMinAmount(params.min.amount0, expectedAmount0, params.maxSlippage);
         } else {
             expectedAmount0 = UniV3UtilsLib.getAmount0Delta(
                 sqrtTwapPriceX96,
@@ -428,7 +425,6 @@ library UniswapV3Lib {
                 expectedLiquidity,
                 false
             );
-            _validateMinAmount(params.min.amount0, expectedAmount0, params.maxSlippage);
 
             expectedAmount1 = UniV3UtilsLib.getAmount1Delta(
                 sqrtRatioLowerX96,
@@ -436,9 +432,10 @@ library UniswapV3Lib {
                 expectedLiquidity,
                 false
             );
-
-            _validateMinAmount(params.min.amount1, expectedAmount1, params.maxSlippage);
         }
+
+        _validateMinAmount(params.min.amount0, expectedAmount0, params.maxSlippage);
+        _validateMinAmount(params.min.amount1, expectedAmount1, params.maxSlippage);
     }
 
     function _validateMinAmount(uint256 minAmount, uint256 expectedAmount, uint256 maxSlippage) internal pure {

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -81,16 +81,6 @@ library UniswapV3Lib {
         uint256                     deadline;
     }
 
-<<<<<<< HEAD
-    struct TwapParams {
-        uint32       twapSecondsAgo;
-        Tick         tick;
-        TokenAmounts target;
-        TokenAmounts min;
-
-    }
-=======
->>>>>>> 0600a3c (use twap tick for swap)
 
     /**********************************************************************************************/
     /*** External functions                                                                     ***/
@@ -100,20 +90,9 @@ library UniswapV3Lib {
     function swap(UniV3Context calldata context, SwapParams calldata params) external returns (uint256 amountOut) {
         require(params.maxSlippage > 0,                                 "UniswapV3Lib/max-slippage-not-set");
         require(params.tickDelta <= params.poolParams.swapMaxTickDelta, "UniswapV3Lib/invalid-max-tick-delta");
-<<<<<<< HEAD
-        require(params.twapSecondsAgo != 0,                             "UniswapV3Lib/zero-twap-seconds");
-
-        _validateMinAmountsTwap(context, TwapParams({
-            twapSecondsAgo : params.twapSecondsAgo,
-            tick           : params.tick,
-            target         : params.target,
-            min            : params.min
-        }));
-=======
         require(params.poolParams.twapSecondsAgo != 0,                  "UniswapV3Lib/zero-twap-seconds");
 
         SwapCache memory cache = _populateSwapCache(context, params);
->>>>>>> 0600a3c (use twap tick for swap)
 
         context.rateLimits.triggerRateLimitDecrease(
             RateLimitHelpers.makeAssetDestinationKey(context.rateLimitId, params.tokenIn, context.pool),

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -7,11 +7,12 @@ import { IERC20Metadata } from "openzeppelin-contracts/contracts/token/ERC20/ext
 import { ERC20Lib } from "./common/ERC20Lib.sol";
 import { MathLib }  from "./common/MathLib.sol";
 
+import { UniV3UtilsLib, TickMath, LiquidityAmounts, FullMath } from "./uniswap-v3/UniV3UtilsLib.sol";
+import { UniswapV3OracleLib }                                  from "./uniswap-v3/UniV3OracleLib.sol";
+
 import { IALMProxy }                                                    from "../interfaces/IALMProxy.sol";
 import { IRateLimits }                                                  from "../interfaces/IRateLimits.sol";
 import { ISwapRouter, IUniswapV3PoolLike, INonfungiblePositionManager } from "../interfaces/UniswapV3Interfaces.sol";
-
-import { TickMath } from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
 
 import { RateLimitHelpers } from "../RateLimitHelpers.sol";
 
@@ -34,6 +35,7 @@ library UniswapV3Lib {
     struct UniswapV3PoolParams {
         uint24 swapMaxTickDelta;
         Tick   addLiquidityTickBounds;
+        uint32 twapSecondsAgo;
     }
 
     struct UniV3Context {
@@ -67,6 +69,7 @@ library UniswapV3Lib {
         TokenAmounts                min;
         uint256                     maxSlippage;
         uint256                     deadline;
+        uint32                      twapSecondsAgo;
     }
 
     struct RemoveLiquidityParams {
@@ -112,7 +115,8 @@ library UniswapV3Lib {
             "UniswapV3Lib/zero-amount"
         );
 
-        require(params.maxSlippage > 0, "UniswapV3Lib/max-slippage-not-set");
+        require(params.maxSlippage > 0,     "UniswapV3Lib/max-slippage-not-set");
+        require(params.twapSecondsAgo != 0, "UniswapV3Lib/zero-twap-seconds");
 
         IUniswapV3PoolLike pool = IUniswapV3PoolLike(context.pool);
 
@@ -121,6 +125,8 @@ library UniswapV3Lib {
 
         ERC20Lib.approve(context.proxy, token0, address(params.positionManager), params.target.amount0);
         ERC20Lib.approve(context.proxy, token1, address(params.positionManager), params.target.amount1);
+
+        _validateAddLiquidityMinAmounts(context, params);
 
         uint256 startingBalance0 = IERC20(token0).balanceOf(address(context.proxy));
         uint256 startingBalance1 = IERC20(token1).balanceOf(address(context.proxy));
@@ -348,7 +354,7 @@ library UniswapV3Lib {
 
         require(success,              "UniswapV3Lib/positions-call-failed");
         require(result.length >= 384, "UniswapV3Lib/invalid-positions-return-data");
-    
+
         assembly {
             // pointer to the first return slot (nonce)
             let data := add(result, 32)
@@ -376,6 +382,68 @@ library UniswapV3Lib {
             tickLower := signextend(2, tickLower)  // 2 = 24 bits - 1 byte (3 bytes total, 0-indexed = 2)
             tickUpper := signextend(2, tickUpper)
         }
+    }
+
+    function _validateAddLiquidityMinAmounts(UniV3Context calldata context, AddLiquidityParams calldata params) internal view {
+        // Fetch twap tick
+        (int24 twapTick, ) = UniswapV3OracleLib.consult(context.pool, params.twapSecondsAgo);
+
+        uint160 sqrtTwapPriceX96   = TickMath.getSqrtRatioAtTick(twapTick);
+        uint160 sqrtRatioLowerX96  = TickMath.getSqrtRatioAtTick(params.tick.lower);
+        uint160 sqrtRatioUpperX96  = TickMath.getSqrtRatioAtTick(params.tick.upper);
+
+        uint128 expectedLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            sqrtTwapPriceX96,
+            sqrtRatioLowerX96,
+            sqrtRatioUpperX96,
+            params.target.amount0,
+            params.target.amount1
+        );
+
+        uint256 expectedAmount0;
+        uint256 expectedAmount1;
+
+        if (twapTick <= params.tick.lower) {
+            expectedAmount0 = UniV3UtilsLib.getAmount0Delta(
+                sqrtRatioLowerX96,
+                sqrtRatioUpperX96,
+                expectedLiquidity,
+                false
+            );
+
+            _validateMinAmount(params.min.amount0, expectedAmount0, params.maxSlippage);
+        } else if (twapTick >= params.tick.upper) {
+            expectedAmount1 = UniV3UtilsLib.getAmount1Delta(
+                sqrtRatioLowerX96,
+                sqrtRatioUpperX96,
+                expectedLiquidity,
+                false
+            );
+
+            _validateMinAmount(params.min.amount0, expectedAmount0, params.maxSlippage);
+        } else {
+            expectedAmount0 = UniV3UtilsLib.getAmount0Delta(
+                sqrtTwapPriceX96,
+                sqrtRatioUpperX96,
+                expectedLiquidity,
+                false
+            );
+            _validateMinAmount(params.min.amount0, expectedAmount0, params.maxSlippage);
+
+            expectedAmount1 = UniV3UtilsLib.getAmount1Delta(
+                sqrtRatioLowerX96,
+                sqrtTwapPriceX96,
+                expectedLiquidity,
+                false
+            );
+
+            _validateMinAmount(params.min.amount1, expectedAmount1, params.maxSlippage);
+        }
+    }
+
+    function _validateMinAmount(uint256 minAmount, uint256 expectedAmount, uint256 maxSlippage) internal pure {
+        uint256 minAmountThreshold = FullMath.mulDiv(expectedAmount, maxSlippage, 1e18);
+        require(minAmount >= minAmountThreshold, "UniswapV3Lib/min-amount-below-bound");
     }
 
     function _validateRemoveLiquidityParams(IUniswapV3PoolLike pool, RemoveLiquidityParams calldata params) internal view returns (address token0, address token1) {

--- a/src/libraries/uniswap-v3/UniV3OracleLib.sol
+++ b/src/libraries/uniswap-v3/UniV3OracleLib.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
+// Use dss-allocator instead of Uniswap implementations to be compatible with Solidity 0.8.xx
 import { FullMath } from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
 import { TickMath } from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
 
@@ -15,7 +16,7 @@ library UniswapV3OracleLib {
     /// @return harmonicMeanLiquidity The harmonic mean liquidity from (block.timestamp - secondsAgo) to block.timestamp
     /// Changes: changed the require message, explicitly cast secondsAgo to int32, and UniswapV3PoolLike to IUniswapV3PoolLike
     function consult(address pool, uint32 secondsAgo)
-        external
+        internal
         view
         returns (int24 arithmeticMeanTick, uint128 harmonicMeanLiquidity)
     {
@@ -52,7 +53,7 @@ library UniswapV3OracleLib {
         uint128 baseAmount,
         address baseToken,
         address quoteToken
-    ) external pure returns (uint256 quoteAmount) {
+    ) internal pure returns (uint256 quoteAmount) {
         uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(tick);
 
         // Calculate quoteAmount with better precision if it doesn't overflow when multiplied by itself

--- a/src/libraries/uniswap-v3/UniV3OracleLib.sol
+++ b/src/libraries/uniswap-v3/UniV3OracleLib.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.21;
+
+import { FullMath } from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
+import { TickMath } from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
+
+import { IUniswapV3PoolLike } from "../../interfaces/UniswapV3Interfaces.sol";
+
+library UniswapV3OracleLib {
+    /// Taken from https://github.com/Uniswap/v3-periphery/blob/main/contracts/libraries/OracleLibrary.sol
+    /// @notice Calculates time-weighted means of tick and liquidity for a given Uniswap V3 pool
+    /// @param pool Address of the pool that we want to observe
+    /// @param secondsAgo Number of seconds in the past from which to calculate the time-weighted means
+    /// @return arithmeticMeanTick The arithmetic mean tick from (block.timestamp - secondsAgo) to block.timestamp
+    /// @return harmonicMeanLiquidity The harmonic mean liquidity from (block.timestamp - secondsAgo) to block.timestamp
+    /// Changes: changed the require message, explicitly cast secondsAgo to int32, and UniswapV3PoolLike to IUniswapV3PoolLike
+    function consult(address pool, uint32 secondsAgo)
+        external
+        view
+        returns (int24 arithmeticMeanTick, uint128 harmonicMeanLiquidity)
+    {
+        require(secondsAgo != 0, 'UniswapV3Lib/consult-seconds-ago-not-zero');
+
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0]              = secondsAgo;
+        secondsAgos[1]              = 0;
+
+        (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s) =
+            IUniswapV3PoolLike(pool).observe(secondsAgos);
+
+        int56 tickCumulativesDelta                  = tickCumulatives[1] - tickCumulatives[0];
+        uint160 secondsPerLiquidityCumulativesDelta = secondsPerLiquidityCumulativeX128s[1] - secondsPerLiquidityCumulativeX128s[0];
+
+        arithmeticMeanTick = int24(tickCumulativesDelta / int32(secondsAgo));
+        // Always round to negative infinity
+        if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int32(secondsAgo) != 0)) arithmeticMeanTick--;
+
+        // We are multiplying here instead of shifting to ensure that harmonicMeanLiquidity doesn't overflow uint128
+        uint192 secondsAgoX160 = uint192(secondsAgo) * type(uint160).max;
+        harmonicMeanLiquidity  = uint128(secondsAgoX160 / (uint192(secondsPerLiquidityCumulativesDelta) << 32));
+    }
+
+    /// Taken from https://github.com/Uniswap/v3-periphery/blob/main/contracts/libraries/OracleLibrary.sol
+    /// @notice Given a tick and a token amount, calculates the amount of token received in exchange
+    /// @param tick Tick value used to calculate the quote
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function getQuoteAtTick(
+        int24 tick,
+        uint128 baseAmount,
+        address baseToken,
+        address quoteToken
+    ) external pure returns (uint256 quoteAmount) {
+        uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(tick);
+
+        // Calculate quoteAmount with better precision if it doesn't overflow when multiplied by itself
+        if (sqrtRatioX96 <= type(uint128).max) {
+            uint256 ratioX192 = uint256(sqrtRatioX96) * sqrtRatioX96;
+            quoteAmount       = baseToken < quoteToken
+                                ? FullMath.mulDiv(ratioX192, baseAmount, 1 << 192)
+                                : FullMath.mulDiv(1 << 192, baseAmount, ratioX192);
+        } else {
+            uint256 ratioX128 = FullMath.mulDiv(sqrtRatioX96, sqrtRatioX96, 1 << 64);
+            quoteAmount       = baseToken < quoteToken
+                                ? FullMath.mulDiv(ratioX128, baseAmount, 1 << 128)
+                                : FullMath.mulDiv(1 << 128, baseAmount, ratioX128);
+        }
+    }
+}

--- a/src/libraries/uniswap-v3/UniV3UtilsLib.sol
+++ b/src/libraries/uniswap-v3/UniV3UtilsLib.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// From dss-allocator/test/funnels/UniV3Utils.sol
+pragma solidity ^0.8.16;
+
+import {LiquidityAmounts, FixedPoint96} from "dss-allocator/src/funnels/uniV3/LiquidityAmounts.sol";
+import {TickMath}                       from "dss-allocator/src/funnels/uniV3/TickMath.sol";
+import {FullMath}                       from "dss-allocator/src/funnels/uniV3/FullMath.sol";
+
+interface UniV3PoolLike {
+    function slot0() external view returns (
+        uint160 sqrtPriceX96,
+        int24 tick,
+        uint16 observationIndex,
+        uint16 observationCardinality,
+        uint16 observationCardinalityNext,
+        uint8 feeProtocol,
+        bool unlocked
+    );
+
+    struct PositionInfo {
+        uint128 liquidity;
+        uint256 feeGrowthInside0LastX128;
+        uint256 feeGrowthInside1LastX128;
+        uint128 tokensOwed0;
+        uint128 tokensOwed1;
+    }
+
+    function positions(bytes32) external view returns (PositionInfo memory);
+}
+
+// https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SafeCast.sol
+library SafeCast {
+
+    function toInt256(uint256 y) internal pure returns (int256 z) {
+        require(y < 2**255);
+        z = int256(y);
+    }
+}
+
+library UniV3UtilsLib {
+    using SafeCast for uint256;
+    using SafeCast for int256;
+
+    // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/UnsafeMath.sol#L12
+    function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        assembly {
+            z := add(div(x, y), gt(mod(x, y), 0))
+        }
+    }
+
+    // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L153
+    function getAmount0Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) internal pure returns (uint256 amount0) {
+        unchecked {
+            if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+            uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+            uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+
+            require(sqrtRatioAX96 > 0);
+
+            return
+                roundUp
+                    ? divRoundingUp(
+                        FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96),
+                        sqrtRatioAX96
+                    )
+                    : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
+        }
+    }
+
+    // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L182
+    function getAmount1Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) internal pure returns (uint256 amount1) {
+        unchecked {
+            if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+            return
+                roundUp
+                    ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
+                    : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+        }
+    }
+
+    // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L201
+    function getAmount0Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        int128 liquidity
+    ) internal pure returns (int256 amount0) {
+        unchecked {
+            return
+                liquidity < 0
+                    ? -getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                    : getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+        }
+    }
+
+    // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L217C7-L217C7
+    function getAmount1Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        int128 liquidity
+    ) internal pure returns (int256 amount1) {
+        unchecked {
+            return
+                liquidity < 0
+                    ? -getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                    : getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+        }
+    }
+}

--- a/src/libraries/uniswap-v3/UniV3UtilsLib.sol
+++ b/src/libraries/uniswap-v3/UniV3UtilsLib.sol
@@ -55,22 +55,20 @@ library UniV3UtilsLib {
         uint128 liquidity,
         bool    roundUp
     ) internal pure returns (uint256 amount0) {
-        unchecked {
-            if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
 
-            uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
-            uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+        uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+        uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
 
-            require(sqrtRatioAX96 > 0);
+        require(sqrtRatioAX96 > 0);
 
-            return
-                roundUp
-                    ? divRoundingUp(
-                        FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96),
-                        sqrtRatioAX96
-                    )
-                    : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
-        }
+        return
+            roundUp
+                ? divRoundingUp(
+                    FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96),
+                    sqrtRatioAX96
+                )
+                : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
     }
 
     // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L182
@@ -80,14 +78,12 @@ library UniV3UtilsLib {
         uint128 liquidity,
         bool    roundUp
     ) internal pure returns (uint256 amount1) {
-        unchecked {
-            if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
 
-            return
-                roundUp
-                    ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
-                    : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
-        }
+        return
+            roundUp
+                ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
+                : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
     }
 
     // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L201
@@ -96,12 +92,10 @@ library UniV3UtilsLib {
         uint160 sqrtRatioBX96,
         int128  liquidity
     ) internal pure returns (int256 amount0) {
-        unchecked {
-            return
-                liquidity < 0
-                    ? -getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
-                    : getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
-        }
+        return
+            liquidity < 0
+                ? -getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                : getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
     }
 
     // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L217C7-L217C7
@@ -110,11 +104,9 @@ library UniV3UtilsLib {
         uint160 sqrtRatioBX96,
         int128  liquidity
     ) internal pure returns (int256 amount1) {
-        unchecked {
-            return
-                liquidity < 0
-                    ? -getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
-                    : getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
-        }
+        return
+            liquidity < 0
+                ? -getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+                : getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
     }
 }

--- a/src/libraries/uniswap-v3/UniV3UtilsLib.sol
+++ b/src/libraries/uniswap-v3/UniV3UtilsLib.sol
@@ -9,12 +9,12 @@ import {FullMath}                       from "dss-allocator/src/funnels/uniV3/Fu
 interface UniV3PoolLike {
     function slot0() external view returns (
         uint160 sqrtPriceX96,
-        int24 tick,
-        uint16 observationIndex,
-        uint16 observationCardinality,
-        uint16 observationCardinalityNext,
-        uint8 feeProtocol,
-        bool unlocked
+        int24   tick,
+        uint16  observationIndex,
+        uint16  observationCardinality,
+        uint16  observationCardinalityNext,
+        uint8   feeProtocol,
+        bool    unlocked
     );
 
     struct PositionInfo {
@@ -53,7 +53,7 @@ library UniV3UtilsLib {
         uint160 sqrtRatioAX96,
         uint160 sqrtRatioBX96,
         uint128 liquidity,
-        bool roundUp
+        bool    roundUp
     ) internal pure returns (uint256 amount0) {
         unchecked {
             if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
@@ -78,7 +78,7 @@ library UniV3UtilsLib {
         uint160 sqrtRatioAX96,
         uint160 sqrtRatioBX96,
         uint128 liquidity,
-        bool roundUp
+        bool    roundUp
     ) internal pure returns (uint256 amount1) {
         unchecked {
             if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
@@ -94,7 +94,7 @@ library UniV3UtilsLib {
     function getAmount0Delta(
         uint160 sqrtRatioAX96,
         uint160 sqrtRatioBX96,
-        int128 liquidity
+        int128  liquidity
     ) internal pure returns (int256 amount0) {
         unchecked {
             return
@@ -108,7 +108,7 @@ library UniV3UtilsLib {
     function getAmount1Delta(
         uint160 sqrtRatioAX96,
         uint160 sqrtRatioBX96,
-        int128 liquidity
+        int128  liquidity
     ) internal pure returns (int256 amount1) {
         unchecked {
             return

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -597,6 +597,227 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
     }
 }
 
+contract ForeignControllerAddLiquidityTwapProtectionTests is UniswapV3TestBase {
+
+    function _defaultDesiredPosition() internal view returns (UniswapV3Lib.TokenAmounts memory) {
+        uint256 amount0 = 10_000 * 10 ** uint256(token0Decimals);
+        uint256 amount1 = 10_000 * 10 ** uint256(IERC20Metadata(address(token1)).decimals());
+
+        return UniswapV3Lib.TokenAmounts({ amount0: amount0, amount1: amount1 });
+    }
+
+    function _mockSpotTick(int24 spotTick) internal {
+        // Mock slot0 to return a manipulated spot tick
+        // slot0 returns: (sqrtPriceX96, tick, observationIndex, observationCardinality, observationCardinalityNext, feeProtocol, unlocked)
+        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(spotTick);
+        vm.mockCall(
+            _getPool(),
+            abi.encodeWithSignature("slot0()"),
+            abi.encode(sqrtPriceX96, spotTick, uint16(0), uint16(1), uint16(1), uint8(0), true)
+        );
+    }
+
+    // Transaction fails when spot price has been manipulated out of expected range
+    // Even with valid TWAP-based min amounts, Uniswap's own slippage check fails
+    // because spot price requires different token ratios than our mins allow
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenSpotPriceManipulated() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Position range around current TWAP (which is close to spot in normal conditions)
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: initTick - 100,
+            upper: initTick + 100
+        });
+
+        // Mock spot price to be way above our tick range (manipulated)
+        // At this spot price, Uniswap will want mostly token1, not the balanced amounts we're providing
+        _mockSpotTick(tick.upper + 1000);
+
+        // Min amounts are valid per TWAP, but spot price is manipulated
+        // Uniswap's mint will fail because actual amounts needed don't match our mins
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 98 / 100,
+            amount1: desired.amount1 * 98 / 100
+        });
+
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("Price slippage check");
+        foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    // When TWAP tick is above tick.upper, expectedAmount0 = 0
+    // So minAmount0 must be 0, otherwise revert
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenTwapAboveRangeAndMinAmount0NonZero() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Set governance bounds entirely below the current TWAP
+        // Pool's TWAP is near initTick, so setting bounds below that puts TWAP above our allowed range
+        vm.startPrank(GROVE_EXECUTOR);
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), initTick - 300);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), initTick - 100);
+        vm.stopPrank();
+
+        // Relayer uses ticks within governance bounds
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: initTick - 200,
+            upper: initTick - 100
+        });
+
+        // Incorrectly provide non-zero minAmount0 when TWAP expects only token1
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: 1, // Should be 0 when twapTick >= tick.upper
+            amount1: desired.amount1 * 98 / 100
+        });
+
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // When TWAP tick is below tick.lower, expectedAmount1 = 0
+    // So minAmount1 must be 0, otherwise revert
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenTwapBelowRangeAndMinAmount1NonZero() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Set governance bounds entirely above the current TWAP
+        // Pool's TWAP is near initTick, so setting bounds above that puts TWAP below our allowed range
+        vm.startPrank(GROVE_EXECUTOR);
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), initTick + 100);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), initTick + 300);
+        vm.stopPrank();
+
+        // Relayer uses ticks within governance bounds
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: initTick + 100,
+            upper: initTick + 200
+        });
+
+        // Incorrectly provide non-zero minAmount1 when TWAP expects only token0
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 98 / 100,
+            amount1: 1 // Should be 0 when twapTick <= tick.lower
+        });
+
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // When TWAP is within tick range, minAmount0 must meet threshold
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenMinAmount0TooLow() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Position range around current TWAP, so both tokens are expected
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: initTick - 100,
+            upper: initTick + 100
+        });
+
+        // minAmount0 is too low (50%) while maxSlippage requires 98%
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 50 / 100, // Too low
+            amount1: desired.amount1 * 98 / 100  // Acceptable
+        });
+
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // When TWAP is within tick range, minAmount1 must meet threshold
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenMinAmount1TooLow() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Position range around current TWAP, so both tokens are expected
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: initTick - 100,
+            upper: initTick + 100
+        });
+
+        // minAmount1 is too low (50%) while maxSlippage requires 98%
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 98 / 100, // Acceptable
+            amount1: desired.amount1 * 50 / 100  // Too low
+        });
+
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // Adding liquidity succeeds when spot price matches TWAP (normal conditions)
+    function test_addLiquidityUniswapV3_twapProtection_succeedsWhenPriceMatchesTwap() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: initTick - 100,
+            upper: initTick + 100
+        });
+
+        vm.startPrank(ALM_RELAYER);
+        (uint256 tokenId, uint128 liquidity,,) = foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+
+        assertGt(liquidity, 0, "Should successfully add liquidity");
+        assertGt(tokenId, 0, "Should mint position NFT");
+    }
+}
+
 contract ForeignControllerAddLiquidityE2EUniswapV3Test is UniswapV3TestBase {
     function _addLiquidityAndValidate(
         uint256 currentTokenId,

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -179,14 +179,14 @@ contract UniswapV3TestBase is ForkTestBase {
     }
 
     function _addLiquidity(
-        uint256                          _tokenId, 
-        UniswapV3Lib.Tick         memory _tick, 
-        UniswapV3Lib.TokenAmounts memory _desired, 
+        uint256                          _tokenId,
+        UniswapV3Lib.Tick         memory _tick,
+        UniswapV3Lib.TokenAmounts memory _desired,
         UniswapV3Lib.TokenAmounts memory _min
     ) internal returns (
-        uint256 tokenId, 
-        uint128 liquidity, 
-        uint256 amount0Used, 
+        uint256 tokenId,
+        uint128 liquidity,
+        uint256 amount0Used,
         uint256 amount1Used
     ) {
         vm.startPrank(ALM_RELAYER);
@@ -1159,7 +1159,7 @@ contract ForeignControllerRemoveLiquidityE2EUniswapV3Test is UniswapV3TestBase {
 
         (tokenId, totalLiquidity, amount0Added, amount1Added) = _addLiquidity(
             addAmount0,
-            addAmount1, 
+            addAmount1,
             UniswapV3Lib.Tick({lower : -100, upper : 100})
         );
     }
@@ -1177,7 +1177,7 @@ contract ForeignControllerRemoveLiquidityE2EUniswapV3Test is UniswapV3TestBase {
 
         vm.warp(block.timestamp + 2 hours); // Advance sufficient time for twap
     }
-    
+
     function _removeLiquidityAndValidate(uint256 tokenId, uint128 liquidity, uint256 minAmount0, uint256 minAmount1, bytes32 token0RateLimitKey, bytes32 token1RateLimitKey) internal returns (uint256 amount0Used, uint256 amount1Used) {
         uint256 token0RateLimitBefore = rateLimits.getCurrentRateLimit(token0RateLimitKey);
         uint256 token1RateLimitBefore = rateLimits.getCurrentRateLimit(token1RateLimitKey);
@@ -1215,22 +1215,22 @@ contract ForeignControllerRemoveLiquidityE2EUniswapV3UsdsUsdcTest is ForeignCont
         uint256 minAmount1 = amount1Added * liquidity / totalLiquidity;
 
         _removeLiquidityAndValidate(
-            tokenId, 
-            liquidity, 
+            tokenId,
+            liquidity,
             minAmount0 * 9999/10000,
-            minAmount1 * 9999/10000, 
-            uniswapV3_UsdsUsdcPool_UsdsRemoveLiquidityKey, 
+            minAmount1 * 9999/10000,
+            uniswapV3_UsdsUsdcPool_UsdsRemoveLiquidityKey,
             uniswapV3_UsdsUsdcPool_UsdcRemoveLiquidityKey
         );
     }
 
     function test_e2e_removeLiquidityUniswapV3_usdsUsdc_allLiquidity() public {
         _removeLiquidityAndValidate(
-            tokenId, 
-            totalLiquidity, 
+            tokenId,
+            totalLiquidity,
             amount0Added * 9999/10000,
-            amount1Added * 9999/10000, 
-            uniswapV3_UsdsUsdcPool_UsdsRemoveLiquidityKey, 
+            amount1Added * 9999/10000,
+            uniswapV3_UsdsUsdcPool_UsdsRemoveLiquidityKey,
             uniswapV3_UsdsUsdcPool_UsdcRemoveLiquidityKey
         );
     }
@@ -1248,22 +1248,22 @@ contract ForeignControllerRemoveLiquidityE2EUniswapV3AusdUsdsTest is ForeignCont
         uint256 minAmount1 = amount1Added * liquidity / totalLiquidity;
 
         _removeLiquidityAndValidate(
-            tokenId, 
-            liquidity, 
+            tokenId,
+            liquidity,
             minAmount0 * 9999/10000,
-            minAmount1 * 9999/10000, 
-            uniswapV3_AusdUsdsPool_UsdsRemoveLiquidityKey, 
+            minAmount1 * 9999/10000,
+            uniswapV3_AusdUsdsPool_UsdsRemoveLiquidityKey,
             uniswapV3_AusdUsdsPool_AusdRemoveLiquidityKey
         );
     }
 
     function test_e2e_removeLiquidityUniswapV3_ausdUsds_allLiquidity() public {
         _removeLiquidityAndValidate(
-            tokenId, 
-            totalLiquidity, 
+            tokenId,
+            totalLiquidity,
             amount0Added * 9999/10000,
-            amount1Added * 9999/10000, 
-            uniswapV3_AusdUsdsPool_UsdsRemoveLiquidityKey, 
+            amount1Added * 9999/10000,
+            uniswapV3_AusdUsdsPool_UsdsRemoveLiquidityKey,
             uniswapV3_AusdUsdsPool_AusdRemoveLiquidityKey
         );
     }

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -2,8 +2,6 @@
 pragma solidity >=0.8.0;
 
 import { IERC20 }                 from "forge-std/interfaces/IERC20.sol";
-import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
-
 import { IERC20Metadata } from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import { UniV3Utils } from "lib/dss-allocator/test/funnels/UniV3Utils.sol";
@@ -249,7 +247,6 @@ contract ForeignControllerConfigFailureTests is UniswapV3TestBase {
 }
 
 contract ForeignControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
-    using stdStorage for StdStorage;
 
     function test_setUniswapV3PoolMaxTickDelta_notAdmin() public {
         vm.expectRevert(abi.encodeWithSignature(
@@ -321,7 +318,6 @@ contract ForeignControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
 }
 
 contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
-    using stdStorage for StdStorage;
 
     function _defaultTickRange() internal view returns (UniswapV3Lib.Tick memory) {
         return UniswapV3Lib.Tick({ lower: initTick - 100, upper: initTick + 100 });
@@ -931,7 +927,6 @@ contract ForeignControllerAddLiquidityTickBoundsTest is ForeignControllerAddLiqu
 }
 
 contract ForeignControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
-    using stdStorage for StdStorage;
 
     uint256 tokenId;
     uint128 liquidity;

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -106,6 +106,8 @@ contract UniswapV3TestBase is ForkTestBase {
 
         foreignController.setMaxSlippage(_getPool(), 0.98e18);
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), 200);
+        // Pools are new so need a shorter twap for testing
+        foreignController.setUniswapV3TwapSecondsAgo(_getPool(), 1 hours);
         vm.stopPrank();
 
 
@@ -231,7 +233,7 @@ contract ForeignControllerConfigFailureTests is UniswapV3TestBase {
     }
 
     function test_setUniswapv3AddLiquidityLowerTickBound_isTooLarge() public {
-        (, UniswapV3Lib.Tick memory tickBounds) = foreignController.uniswapV3PoolParams(_getPool());
+        (, UniswapV3Lib.Tick memory tickBounds,) = foreignController.uniswapV3PoolParams(_getPool());
         int24 currentUpper = tickBounds.upper;
 
         vm.prank(GROVE_EXECUTOR);

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -13,6 +13,7 @@ import { UniswapV3Lib }                                    from "../../src/libra
 
 import { UniV3Utils } from "lib/dss-allocator/test/funnels/UniV3Utils.sol";
 import { FullMath }   from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
+import { TickMath }   from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
 
 interface IUniswapV3PoolLikeTickSpacing is IUniswapV3PoolLike {
     function tickSpacing() external view returns (int24);
@@ -230,7 +231,6 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
 }
 
 contract MainnetControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
-    using stdStorage for StdStorage;
 
     function test_swapUniswapV3_notRelayer() public {
         vm.expectRevert(abi.encodeWithSignature(
@@ -526,7 +526,6 @@ contract MainnetControllerE2EUniswapV3UsdcUsdtPoolTest is MainnetControllerE2EUn
 }
 
 contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
-    using stdStorage for StdStorage;
 
     function _defaultTickRange() internal view returns (UniswapV3Lib.Tick memory) {
         return UniswapV3Lib.Tick({ lower: _toSpacedTick(initTick - 100), upper: _toSpacedTick(initTick + 100) });
@@ -915,11 +914,6 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
 }
 
 contract MainnetControllerAddLiquidityTwapProtectionTests is UniswapV3TestBase {
-    using stdStorage for StdStorage;
-
-    function _defaultTickRange() internal view returns (UniswapV3Lib.Tick memory) {
-        return UniswapV3Lib.Tick({ lower: _toSpacedTick(initTick - 100), upper: _toSpacedTick(initTick + 100) });
-    }
 
     function _defaultDesiredPosition() internal view returns (UniswapV3Lib.TokenAmounts memory) {
         uint256 amount0 = 10_000 * 10 ** uint256(token0Decimals);
@@ -928,12 +922,201 @@ contract MainnetControllerAddLiquidityTwapProtectionTests is UniswapV3TestBase {
         return UniswapV3Lib.TokenAmounts({ amount0: amount0, amount1: amount1 });
     }
 
+    function _mockSpotTick(int24 spotTick) internal {
+        // Mock slot0 to return a manipulated spot tick
+        // slot0 returns: (sqrtPriceX96, tick, observationIndex, observationCardinality, observationCardinalityNext, feeProtocol, unlocked)
+        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(spotTick);
+        vm.mockCall(
+            _getPool(),
+            abi.encodeWithSignature("slot0()"),
+            abi.encode(sqrtPriceX96, spotTick, uint16(0), uint16(1), uint16(1), uint8(0), true)
+        );
+    }
+
+    // Transaction fails when spot price has been manipulated out of expected range
+    // Even with valid TWAP-based min amounts, Uniswap's own slippage check fails
+    // because spot price requires different token ratios than our mins allow
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenSpotPriceManipulated() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Position range around current TWAP (which is close to spot in normal conditions)
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: _toSpacedTick(initTick - 100),
+            upper: _toSpacedTick(initTick + 100)
+        });
+
+        // Mock spot price to be way above our tick range (manipulated)
+        // At this spot price, Uniswap will want mostly token1, not the balanced amounts we're providing
+        _mockSpotTick(tick.upper + 1000);
+
+        // Min amounts are valid per TWAP, but spot price is manipulated
+        // Uniswap's mint will fail because actual amounts needed don't match our mins
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 98 / 100,
+            amount1: desired.amount1 * 98 / 100
+        });
+
+        vm.startPrank(relayer);
+        vm.expectRevert("Price slippage check");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    // When TWAP tick is above tick.upper, expectedAmount0 = 0
+    // So minAmount0 must be 0, otherwise revert
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenTwapAboveRangeAndMinAmount0NonZero() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Set governance bounds entirely below the current TWAP
+        // Pool's TWAP is near initTick, so setting bounds below that puts TWAP above our allowed range
+        vm.startPrank(GROVE_PROXY);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), initTick - 300);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), initTick - 100);
+        vm.stopPrank();
+
+        // Relayer uses ticks within governance bounds
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: _toSpacedTick(initTick - 200),
+            upper: _toSpacedTick(initTick - 100)
+        });
+
+        // Incorrectly provide non-zero minAmount0 when TWAP expects only token1
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: 1, // Should be 0 when twapTick >= tick.upper
+            amount1: desired.amount1 * 98 / 100
+        });
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // When TWAP tick is below tick.lower, expectedAmount1 = 0
+    // So minAmount1 must be 0, otherwise revert
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenTwapBelowRangeAndMinAmount1NonZero() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Set governance bounds entirely above the current TWAP
+        // Pool's TWAP is near initTick, so setting bounds above that puts TWAP below our allowed range
+        vm.startPrank(GROVE_PROXY);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), initTick + 100);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), initTick + 300);
+        vm.stopPrank();
+
+        // Relayer uses ticks within governance bounds
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: _toSpacedTick(initTick + 100),
+            upper: _toSpacedTick(initTick + 200)
+        });
+
+        // Incorrectly provide non-zero minAmount1 when TWAP expects only token0
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 98 / 100,
+            amount1: 1 // Should be 0 when twapTick <= tick.lower
+        });
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // When TWAP is within tick range, minAmount0 must meet threshold
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenMinAmount0TooLow() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Position range around current TWAP, so both tokens are expected
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: _toSpacedTick(initTick - 100),
+            upper: _toSpacedTick(initTick + 100)
+        });
+
+        // minAmount0 is too low (50%) while maxSlippage requires 98%
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 50 / 100, // Too low
+            amount1: desired.amount1 * 98 / 100  // Acceptable
+        });
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // When TWAP is within tick range, minAmount1 must meet threshold
+    function test_addLiquidityUniswapV3_twapProtection_revertsWhenMinAmount1TooLow() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Position range around current TWAP, so both tokens are expected
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: _toSpacedTick(initTick - 100),
+            upper: _toSpacedTick(initTick + 100)
+        });
+
+        // minAmount1 is too low (50%) while maxSlippage requires 98%
+        UniswapV3Lib.TokenAmounts memory minAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 98 / 100, // Acceptable
+            amount1: desired.amount1 * 50 / 100  // Too low
+        });
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            minAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
     // Test: Adding liquidity succeeds when spot price matches TWAP (normal conditions)
     function test_addLiquidityUniswapV3_twapProtection_succeedsWhenPriceMatchesTwap() public {
         UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
         _fundProxy(desired.amount0, desired.amount1);
 
-        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+        UniswapV3Lib.Tick memory tick = UniswapV3Lib.Tick({
+            lower: _toSpacedTick(initTick - 100),
+            upper: _toSpacedTick(initTick + 100)
+        });
 
         vm.startPrank(relayer);
         (uint256 tokenId, uint128 liquidity,,) = mainnetController.addLiquidityUniswapV3(
@@ -948,195 +1131,6 @@ contract MainnetControllerAddLiquidityTwapProtectionTests is UniswapV3TestBase {
 
         assertGt(liquidity, 0, "Should successfully add liquidity");
         assertGt(tokenId, 0, "Should mint position NFT");
-    }
-
-    // Test: Adding liquidity fails when user provides tight min amounts that work for spot price
-    // but TWAP expects different amounts due to price divergence
-    // The transaction reverts due to either TWAP validation or pool's own slippage check
-    function test_addLiquidityUniswapV3_twapProtection_failsWithTightMinAmountsAndDivergedTwap() public {
-        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
-        _fundProxy(desired.amount0, desired.amount1);
-
-        (, int24 currentTick,,,,,) = pool.slot0();
-        UniswapV3Lib.Tick memory tick = _defaultTickRange();
-
-        // Mock TWAP to a tick where expected amounts differ significantly
-        int24 manipulatedTwapTick = currentTick + 50;
-        _mockTwapObserve(manipulatedTwapTick);
-
-        // Provide min amounts that are very tight - 99.9%
-        UniswapV3Lib.TokenAmounts memory tightMinAmounts = UniswapV3Lib.TokenAmounts({
-            amount0: desired.amount0 * 999 / 1000,
-            amount1: desired.amount1 * 999 / 1000
-        });
-
-        vm.startPrank(relayer);
-        vm.expectRevert(); // Reverts due to slippage - either TWAP check or pool's check
-        mainnetController.addLiquidityUniswapV3(
-            _getPool(),
-            0,
-            tick,
-            desired,
-            tightMinAmounts,
-            block.timestamp + 1 hours
-        );
-        vm.stopPrank();
-
-        vm.clearMockedCalls();
-    }
-
-    // Test: Adding liquidity fails with asymmetric position and diverged TWAP
-    function test_addLiquidityUniswapV3_twapProtection_failsWithAsymmetricPositionAndDivergedTwap() public {
-        // Use asymmetric amounts - more token0 than token1
-        uint256 amount0 = 20_000 * 10 ** uint256(token0Decimals);
-        uint256 amount1 = 5_000 * 10 ** uint256(IERC20Metadata(address(token1)).decimals());
-        _fundProxy(amount0, amount1);
-
-        (, int24 currentTick,,,,,) = pool.slot0();
-        UniswapV3Lib.Tick memory tick = _defaultTickRange();
-
-        // Mock TWAP to a tick that conflicts with the asymmetric position
-        _mockTwapObserve(currentTick + 80);
-
-        UniswapV3Lib.TokenAmounts memory desired = UniswapV3Lib.TokenAmounts({
-            amount0: amount0,
-            amount1: amount1
-        });
-
-        vm.startPrank(relayer);
-        vm.expectRevert(); // Reverts due to slippage protection
-        mainnetController.addLiquidityUniswapV3(
-            _getPool(),
-            0,
-            tick,
-            desired,
-            _minLiquidityPosition(amount0, amount1),
-            block.timestamp + 1 hours
-        );
-        vm.stopPrank();
-
-        vm.clearMockedCalls();
-    }
-
-    // Test: Verifies twapSecondsAgo=0 reverts (misconfiguration protection)
-    function test_addLiquidityUniswapV3_twapProtection_failsWhenTwapNotConfigured() public {
-        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
-        _fundProxy(desired.amount0, desired.amount1);
-
-        // Set twapSecondsAgo to 0 (misconfigured)
-        vm.prank(GROVE_PROXY);
-        mainnetController.setUniswapV3TwapSecondsAgo(_getPool(), 0);
-
-        UniswapV3Lib.Tick memory tick = _defaultTickRange();
-
-        vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/zero-twap-seconds");
-        mainnetController.addLiquidityUniswapV3(
-            _getPool(),
-            0,
-            tick,
-            desired,
-            _minLiquidityPosition(desired.amount0, desired.amount1),
-            block.timestamp + 1 hours
-        );
-        vm.stopPrank();
-    }
-
-    // Test: Adding liquidity fails when min amounts are too low relative to TWAP expectations
-    function test_addLiquidityUniswapV3_twapProtection_failsWhenMinAmountsTooLow() public {
-        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
-        _fundProxy(desired.amount0, desired.amount1);
-
-        UniswapV3Lib.Tick memory tick = _defaultTickRange();
-
-        // Set min amounts way too low - below maxSlippage threshold (50% vs 98% maxSlippage)
-        vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
-        mainnetController.addLiquidityUniswapV3(
-            _getPool(),
-            0,
-            tick,
-            desired,
-            UniswapV3Lib.TokenAmounts({ amount0: desired.amount0 * 50 / 100, amount1: desired.amount1 * 50 / 100 }),
-            block.timestamp + 1 hours
-        );
-        vm.stopPrank();
-    }
-
-    // Test: Tighter maxSlippage makes TWAP protection stricter
-    function test_addLiquidityUniswapV3_twapProtection_tighterSlippageRequiresHigherMinAmounts() public {
-        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
-        _fundProxy(desired.amount0, desired.amount1);
-
-        // Set very tight maxSlippage (99.5%)
-        vm.prank(GROVE_PROXY);
-        mainnetController.setMaxSlippage(_getPool(), 0.995e18);
-
-        UniswapV3Lib.Tick memory tick = _defaultTickRange();
-
-        // 98% min amounts that would pass with 98% maxSlippage now fail with 99.5%
-        vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
-        mainnetController.addLiquidityUniswapV3(
-            _getPool(),
-            0,
-            tick,
-            desired,
-            _minLiquidityPosition(desired.amount0, desired.amount1),
-            block.timestamp + 1 hours
-        );
-        vm.stopPrank();
-    }
-
-    // Test: Demonstrates that when TWAP aligns with spot price, liquidity addition succeeds
-    function test_addLiquidityUniswapV3_twapProtection_succeedsWhenTwapAlignedWithSpot() public {
-        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
-        UniswapV3Lib.Tick memory tick = _defaultTickRange();
-        (, int24 currentTick,,,,,) = pool.slot0();
-
-        // Mock TWAP to match current spot tick exactly
-        _mockTwapObserve(currentTick);
-        _fundProxy(desired.amount0, desired.amount1);
-
-        vm.startPrank(relayer);
-        (uint256 tokenId, uint128 liquidity,,) = mainnetController.addLiquidityUniswapV3(
-            _getPool(),
-            0,
-            tick,
-            desired,
-            _minLiquidityPosition(desired.amount0, desired.amount1),
-            block.timestamp + 1 hours
-        );
-        vm.stopPrank();
-
-        vm.clearMockedCalls();
-
-        assertGt(liquidity, 0, "Should successfully add liquidity when TWAP aligns with spot");
-        assertGt(tokenId, 0, "Should mint position NFT");
-    }
-
-    function _mockTwapObserve(int24 twapTick) internal {
-        // The TWAP calculation is: arithmeticMeanTick = (tickCumulatives[1] - tickCumulatives[0]) / secondsAgo
-        // So to get a specific twapTick: tickCumulatives[1] - tickCumulatives[0] = twapTick * secondsAgo
-        int56[] memory tickCumulatives = new int56[](2);
-        tickCumulatives[0] = 0;
-        tickCumulatives[1] = int56(twapTick) * int56(int32(86400)); // delta = twapTick * secondsAgo
-
-        uint160[] memory secondsPerLiquidityCumulativeX128s = new uint160[](2);
-        secondsPerLiquidityCumulativeX128s[0] = 0;
-        secondsPerLiquidityCumulativeX128s[1] = 1;
-
-        // Build the exact calldata that will be used
-        uint32[] memory secondsAgos = new uint32[](2);
-        secondsAgos[0] = 86400; // 1 day - matches twapSecondsAgo config
-        secondsAgos[1] = 0;
-
-        // Mock the exact call that will be made
-        vm.mockCall(
-            _getPool(),
-            abi.encodeCall(IUniswapV3PoolLike.observe, (secondsAgos)),
-            abi.encode(tickCumulatives, secondsPerLiquidityCumulativeX128s)
-        );
     }
 }
 
@@ -1285,7 +1279,6 @@ contract MainnetControllerAddLiquidityE2EUniswapV3DaiUsdcTest is MainnetControll
 }
 
 contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
-    using stdStorage for StdStorage;
 
     uint256 tokenId;
     uint128 liquidity;
@@ -1309,14 +1302,14 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
     }
 
     function _defaultDesiredPosition() internal view returns (UniswapV3Lib.TokenAmounts memory) {
-        uint256 amount0 = 1_000 * 10 ** uint256(token0Decimals);
-        uint8 token1Decimals = IERC20Metadata(address(token1)).decimals();
-        uint256 amount1 = 1_000 * 10 ** uint256(token1Decimals);
+        uint256 desiredAmount0 = 1_000 * 10 ** uint256(token0Decimals);
+        uint8 decimals1 = IERC20Metadata(address(token1)).decimals();
+        uint256 desiredAmount1 = 1_000 * 10 ** uint256(decimals1);
 
-        return UniswapV3Lib.TokenAmounts({ amount0: amount0, amount1: amount1 });
+        return UniswapV3Lib.TokenAmounts({ amount0: desiredAmount0, amount1: desiredAmount1 });
     }
 
-    function _mintProxyPosition() internal returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) {
+    function _mintProxyPosition() internal returns (uint256 tokenId_, uint128 liquidity_, uint256 amount0_, uint256 amount1_) {
         UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
         UniswapV3Lib.Tick memory tick = _defaultTickRange();
 
@@ -1327,7 +1320,7 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
         SafeERC20.forceApprove(IERC20OZ(address(token0)), UNISWAP_V3_POSITION_MANAGER, desired.amount0);
         SafeERC20.forceApprove(IERC20OZ(address(token1)), UNISWAP_V3_POSITION_MANAGER, desired.amount1);
 
-        (tokenId, liquidity, amount0, amount1) = INonfungiblePositionManager(UNISWAP_V3_POSITION_MANAGER).mint(
+        (tokenId_, liquidity_, amount0_, amount1_) = INonfungiblePositionManager(UNISWAP_V3_POSITION_MANAGER).mint(
             INonfungiblePositionManager.MintParams({
                 token0: address(token0),
                 token1: address(token1),
@@ -1345,7 +1338,7 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
         vm.stopPrank();
     }
 
-    function _mintExternalPosition() internal returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) {
+    function _mintExternalPosition() internal returns (uint256 tokenId_, uint128 liquidity_, uint256 amount0_, uint256 amount1_) {
         address stranger = makeAddr("stranger-remove-lp");
         UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
 
@@ -1356,7 +1349,7 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
         SafeERC20.forceApprove(IERC20OZ(address(token0)), UNISWAP_V3_POSITION_MANAGER, desired.amount0);
         SafeERC20.forceApprove(IERC20OZ(address(token1)), UNISWAP_V3_POSITION_MANAGER, desired.amount1);
 
-        (tokenId, liquidity, amount0, amount1) = INonfungiblePositionManager(UNISWAP_V3_POSITION_MANAGER).mint(
+        (tokenId_, liquidity_, amount0_, amount1_) = INonfungiblePositionManager(UNISWAP_V3_POSITION_MANAGER).mint(
             INonfungiblePositionManager.MintParams({
                 token0: address(token0),
                 token1: address(token1),
@@ -1393,15 +1386,15 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
     }
 
     function test_removeLiquidityUniswapV3_proxyDoesNotOwnTokenId() public {
-        (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) = _mintExternalPosition();
+        (uint256 externalTokenId, uint128 externalLiquidity,,) = _mintExternalPosition();
 
         vm.warp(block.timestamp + 1 hours);
         vm.startPrank(relayer);
         vm.expectRevert("UniswapV3Lib/proxy-does-not-own-token-id");
         mainnetController.removeLiquidityUniswapV3(
             _getPool(),
-            tokenId,
-            liquidity,
+            externalTokenId,
+            externalLiquidity,
             UniswapV3Lib.TokenAmounts({ amount0: defaultMinAmount0, amount1: defaultMinAmount1 }),
             block.timestamp + 1 hours
         );
@@ -1520,11 +1513,11 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3Test is UniswapV3TestBase {
         );
     }
 
-    function _addLiquidity(uint256 addAmount0, uint256 addAmount1, UniswapV3Lib.Tick memory addTickDelta) internal returns (uint256 tokenId, uint128 liquidity, uint256 amount0Used, uint256 amount1Used) {
+    function _addLiquidity(uint256 addAmount0, uint256 addAmount1, UniswapV3Lib.Tick memory addTickDelta) internal returns (uint256 tokenId_, uint128 liquidity_, uint256 amount0Used, uint256 amount1Used) {
         deal(address(token0), address(almProxy), addAmount0);
         deal(address(token1), address(almProxy), addAmount1);
 
-        (tokenId, liquidity, amount0Used, amount1Used) = _addLiquidity(
+        (tokenId_, liquidity_, amount0Used, amount1Used) = _addLiquidity(
             0,
             UniswapV3Lib.Tick({lower : _toSpacedTick(initTick + addTickDelta.lower), upper : _toSpacedTick(initTick + addTickDelta.upper)}),
             UniswapV3Lib.TokenAmounts({ amount0: addAmount0, amount1: addAmount1 }),
@@ -1534,15 +1527,15 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3Test is UniswapV3TestBase {
         vm.warp(block.timestamp + 2 hours); // Advance sufficient time for twap
     }
 
-    function _removeLiquidityAndValidate(uint256 tokenId, uint128 liquidity, uint256 minAmount0, uint256 minAmount1, bytes32 token0RateLimitKey, bytes32 token1RateLimitKey) internal returns (uint256 amount0Used, uint256 amount1Used) {
+    function _removeLiquidityAndValidate(uint256 tokenId_, uint128 liquidity_, uint256 minAmount0, uint256 minAmount1, bytes32 token0RateLimitKey, bytes32 token1RateLimitKey) internal returns (uint256 amount0Used, uint256 amount1Used) {
         uint256 token0RateLimitBefore = rateLimits.getCurrentRateLimit(token0RateLimitKey);
         uint256 token1RateLimitBefore = rateLimits.getCurrentRateLimit(token1RateLimitKey);
 
         vm.startPrank(relayer);
         (amount0Used, amount1Used) = mainnetController.removeLiquidityUniswapV3(
             _getPool(),
-            tokenId,
-            liquidity,
+            tokenId_,
+            liquidity_,
             UniswapV3Lib.TokenAmounts({ amount0: minAmount0, amount1: minAmount1 }),
             block.timestamp + 1 hours
         );
@@ -1551,8 +1544,8 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3Test is UniswapV3TestBase {
         assertGe(amount0Used, minAmount0, "amount0Used should be greater than or equal to minAmount0");
         assertGe(amount1Used, minAmount1, "amount1Used should be greater than or equal to minAmount1");
 
-        assertApproxEqRel(amount0Used, amount0Added * liquidity / totalLiquidity, .0001e18, "amount0Used should be within 0.01% of amount0Added * liquidity / totalLiquidity");
-        assertApproxEqRel(amount1Used, amount1Added * liquidity / totalLiquidity, .0001e18, "amount1Used should be within 0.01% of amount1Added * liquidity / totalLiquidity");
+        assertApproxEqRel(amount0Used, amount0Added * liquidity_ / totalLiquidity, .0001e18, "amount0Used should be within 0.01% of amount0Added * liquidity / totalLiquidity");
+        assertApproxEqRel(amount1Used, amount1Added * liquidity_ / totalLiquidity, .0001e18, "amount1Used should be within 0.01% of amount1Added * liquidity / totalLiquidity");
 
         uint256 token0RateLimitAfter = rateLimits.getCurrentRateLimit(token0RateLimitKey);
         uint256 token1RateLimitAfter = rateLimits.getCurrentRateLimit(token1RateLimitKey);

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -20,7 +20,7 @@ interface IUniswapV3PoolLikeTickSpacing is IUniswapV3PoolLike {
 
 contract UniswapV3TestBase is ForkTestBase {
     address constant UNISWAP_V3_USDC_USDT_POOL   = 0x3416cF6C708Da44DB2624D63ea0AAef7113527C6;
-    address constant UNISWAP_V3_DAI_USDC_POOL    = 0x6c6Bc977E13Df9b0de53b251522280BB72383700; 
+    address constant UNISWAP_V3_DAI_USDC_POOL    = 0x6c6Bc977E13Df9b0de53b251522280BB72383700;
 
     int24 internal constant DEFAULT_TICK_LOWER = -600;
     int24 internal constant DEFAULT_TICK_UPPER =  600;
@@ -102,11 +102,11 @@ contract UniswapV3TestBase is ForkTestBase {
         vm.stopPrank();
     }
 
-    
+
     function _getSwapKey(address tokenIn) internal view returns (bytes32) {
         return RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(), tokenIn, _getPool());
     }
-    
+
     function _label() internal {
         vm.label(UNISWAP_V3_ROUTER,           'UniswapV3Router');
         vm.label(UNISWAP_V3_POSITION_MANAGER, 'UniswapV3PositionManager');
@@ -117,7 +117,7 @@ contract UniswapV3TestBase is ForkTestBase {
     function _getPool() internal pure virtual returns (address) {
         return UNISWAP_V3_USDC_USDT_POOL;
     }
-    
+
     function _getBlock() internal pure override returns (uint256) {
         return 23677743;  // Oct 28, 2025
     }
@@ -1289,7 +1289,7 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3Test is UniswapV3TestBase {
 
         (tokenId, totalLiquidity, amount0Added, amount1Added) = _addLiquidity(
             addAmount0,
-            addAmount1, 
+            addAmount1,
             UniswapV3Lib.Tick({lower : -100, upper : 100})
         );
     }
@@ -1307,7 +1307,7 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3Test is UniswapV3TestBase {
 
         vm.warp(block.timestamp + 2 hours); // Advance sufficient time for twap
     }
-    
+
     function _removeLiquidityAndValidate(uint256 tokenId, uint128 liquidity, uint256 minAmount0, uint256 minAmount1, bytes32 token0RateLimitKey, bytes32 token1RateLimitKey) internal returns (uint256 amount0Used, uint256 amount1Used) {
         uint256 token0RateLimitBefore = rateLimits.getCurrentRateLimit(token0RateLimitKey);
         uint256 token1RateLimitBefore = rateLimits.getCurrentRateLimit(token1RateLimitKey);
@@ -1344,22 +1344,22 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3UsdcUsdtTest is MainnetCont
         uint256 minAmount1 = amount1Added * liquidity / totalLiquidity;
 
         _removeLiquidityAndValidate(
-            tokenId, 
-            liquidity, 
+            tokenId,
+            liquidity,
             minAmount0 * 9999/10000,
-            minAmount1 * 9999/10000, 
-            uniswapV3_UsdcUsdtPool_UsdcRemoveLiquidityKey, 
+            minAmount1 * 9999/10000,
+            uniswapV3_UsdcUsdtPool_UsdcRemoveLiquidityKey,
             uniswapV3_UsdcUsdtPool_UsdtRemoveLiquidityKey
         );
     }
 
     function test_e2e_removeLiquidityUniswapV3_usdcUsdt_allLiquidity() public {
         _removeLiquidityAndValidate(
-            tokenId, 
-            totalLiquidity, 
+            tokenId,
+            totalLiquidity,
             amount0Added * 9999/10000,
-            amount1Added * 9999/10000, 
-            uniswapV3_UsdcUsdtPool_UsdcRemoveLiquidityKey, 
+            amount1Added * 9999/10000,
+            uniswapV3_UsdcUsdtPool_UsdcRemoveLiquidityKey,
             uniswapV3_UsdcUsdtPool_UsdtRemoveLiquidityKey
         );
     }
@@ -1377,7 +1377,7 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3DaiUsdcTest is MainnetContr
 
         (tokenId, totalLiquidity, amount0Added, amount1Added) = _addLiquidity(
             addAmount0,
-            addAmount1, 
+            addAmount1,
             UniswapV3Lib.Tick({lower : -100, upper : 100})
         );
     }
@@ -1393,22 +1393,22 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3DaiUsdcTest is MainnetContr
         uint256 minAmount1 = amount1Added * liquidity / totalLiquidity;
 
         _removeLiquidityAndValidate(
-            tokenId, 
-            liquidity, 
+            tokenId,
+            liquidity,
             minAmount0 * 9999/10000,
-            minAmount1 * 9999/10000, 
-            uniswapV3_DaiUsdcPool_DaiRemoveLiquidityKey, 
+            minAmount1 * 9999/10000,
+            uniswapV3_DaiUsdcPool_DaiRemoveLiquidityKey,
             uniswapV3_DaiUsdcPool_UsdcRemoveLiquidityKey
         );
     }
 
     function test_e2e_removeLiquidityUniswapV3_daiUsdc_allLiquidity() public {
         _removeLiquidityAndValidate(
-            tokenId, 
-            totalLiquidity, 
+            tokenId,
+            totalLiquidity,
             amount0Added * 9999/10000,
-            amount1Added * 9999/10000, 
-            uniswapV3_DaiUsdcPool_DaiRemoveLiquidityKey, 
+            amount1Added * 9999/10000,
+            uniswapV3_DaiUsdcPool_DaiRemoveLiquidityKey,
             uniswapV3_DaiUsdcPool_UsdcRemoveLiquidityKey
         );
     }

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -84,6 +84,7 @@ contract UniswapV3TestBase is ForkTestBase {
         mainnetController.setMaxSlippage(_getPool(), 0.98e18);
         // All trades must have no more than 200 ticks impact on the pool. For most stablecoin pools, a tick is 1bps
         mainnetController.setUniswapV3PoolMaxTickDelta(_getPool(), 200);
+        mainnetController.setUniswapV3TwapSecondsAgo(_getPool(), 1 days);
 
         vm.stopPrank();
 
@@ -204,7 +205,7 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
 
 
     function test_setUniswapv3AddLiquidityLowerTickBound_isTooLarge() public {
-        (, UniswapV3Lib.Tick memory tickBounds) = mainnetController.uniswapV3PoolParams(_getPool());
+        (, UniswapV3Lib.Tick memory tickBounds, ) = mainnetController.uniswapV3PoolParams(_getPool());
         int24 currentUpper = tickBounds.upper;
 
         vm.prank(GROVE_PROXY);
@@ -213,7 +214,7 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
     }
 
     function test_setUniswapv3AddLiquidityUpperTickBound_isTooSmall() public {
-        (, UniswapV3Lib.Tick memory tickBounds) = mainnetController.uniswapV3PoolParams(_getPool());
+        (, UniswapV3Lib.Tick memory tickBounds, ) = mainnetController.uniswapV3PoolParams(_getPool());
         int24 currentLower = tickBounds.lower;
 
         vm.prank(GROVE_PROXY);

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -914,6 +914,232 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
     }
 }
 
+contract MainnetControllerAddLiquidityTwapProtectionTests is UniswapV3TestBase {
+    using stdStorage for StdStorage;
+
+    function _defaultTickRange() internal view returns (UniswapV3Lib.Tick memory) {
+        return UniswapV3Lib.Tick({ lower: _toSpacedTick(initTick - 100), upper: _toSpacedTick(initTick + 100) });
+    }
+
+    function _defaultDesiredPosition() internal view returns (UniswapV3Lib.TokenAmounts memory) {
+        uint256 amount0 = 10_000 * 10 ** uint256(token0Decimals);
+        uint256 amount1 = 10_000 * 10 ** uint256(IERC20Metadata(address(token1)).decimals());
+
+        return UniswapV3Lib.TokenAmounts({ amount0: amount0, amount1: amount1 });
+    }
+
+    // Test: Adding liquidity succeeds when spot price matches TWAP (normal conditions)
+    function test_addLiquidityUniswapV3_twapProtection_succeedsWhenPriceMatchesTwap() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+
+        vm.startPrank(relayer);
+        (uint256 tokenId, uint128 liquidity,,) = mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+
+        assertGt(liquidity, 0, "Should successfully add liquidity");
+        assertGt(tokenId, 0, "Should mint position NFT");
+    }
+
+    // Test: Adding liquidity fails when user provides tight min amounts that work for spot price
+    // but TWAP expects different amounts due to price divergence
+    // The transaction reverts due to either TWAP validation or pool's own slippage check
+    function test_addLiquidityUniswapV3_twapProtection_failsWithTightMinAmountsAndDivergedTwap() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        (, int24 currentTick,,,,,) = pool.slot0();
+        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+
+        // Mock TWAP to a tick where expected amounts differ significantly
+        int24 manipulatedTwapTick = currentTick + 50;
+        _mockTwapObserve(manipulatedTwapTick);
+
+        // Provide min amounts that are very tight - 99.9%
+        UniswapV3Lib.TokenAmounts memory tightMinAmounts = UniswapV3Lib.TokenAmounts({
+            amount0: desired.amount0 * 999 / 1000,
+            amount1: desired.amount1 * 999 / 1000
+        });
+
+        vm.startPrank(relayer);
+        vm.expectRevert(); // Reverts due to slippage - either TWAP check or pool's check
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            tightMinAmounts,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    // Test: Adding liquidity fails with asymmetric position and diverged TWAP
+    function test_addLiquidityUniswapV3_twapProtection_failsWithAsymmetricPositionAndDivergedTwap() public {
+        // Use asymmetric amounts - more token0 than token1
+        uint256 amount0 = 20_000 * 10 ** uint256(token0Decimals);
+        uint256 amount1 = 5_000 * 10 ** uint256(IERC20Metadata(address(token1)).decimals());
+        _fundProxy(amount0, amount1);
+
+        (, int24 currentTick,,,,,) = pool.slot0();
+        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+
+        // Mock TWAP to a tick that conflicts with the asymmetric position
+        _mockTwapObserve(currentTick + 80);
+
+        UniswapV3Lib.TokenAmounts memory desired = UniswapV3Lib.TokenAmounts({
+            amount0: amount0,
+            amount1: amount1
+        });
+
+        vm.startPrank(relayer);
+        vm.expectRevert(); // Reverts due to slippage protection
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            _minLiquidityPosition(amount0, amount1),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    // Test: Verifies twapSecondsAgo=0 reverts (misconfiguration protection)
+    function test_addLiquidityUniswapV3_twapProtection_failsWhenTwapNotConfigured() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Set twapSecondsAgo to 0 (misconfigured)
+        vm.prank(GROVE_PROXY);
+        mainnetController.setUniswapV3TwapSecondsAgo(_getPool(), 0);
+
+        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/zero-twap-seconds");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // Test: Adding liquidity fails when min amounts are too low relative to TWAP expectations
+    function test_addLiquidityUniswapV3_twapProtection_failsWhenMinAmountsTooLow() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+
+        // Set min amounts way too low - below maxSlippage threshold (50% vs 98% maxSlippage)
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            UniswapV3Lib.TokenAmounts({ amount0: desired.amount0 * 50 / 100, amount1: desired.amount1 * 50 / 100 }),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // Test: Tighter maxSlippage makes TWAP protection stricter
+    function test_addLiquidityUniswapV3_twapProtection_tighterSlippageRequiresHigherMinAmounts() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        _fundProxy(desired.amount0, desired.amount1);
+
+        // Set very tight maxSlippage (99.5%)
+        vm.prank(GROVE_PROXY);
+        mainnetController.setMaxSlippage(_getPool(), 0.995e18);
+
+        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+
+        // 98% min amounts that would pass with 98% maxSlippage now fail with 99.5%
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/min-amount-below-bound");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    // Test: Demonstrates that when TWAP aligns with spot price, liquidity addition succeeds
+    function test_addLiquidityUniswapV3_twapProtection_succeedsWhenTwapAlignedWithSpot() public {
+        UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
+        UniswapV3Lib.Tick memory tick = _defaultTickRange();
+        (, int24 currentTick,,,,,) = pool.slot0();
+
+        // Mock TWAP to match current spot tick exactly
+        _mockTwapObserve(currentTick);
+        _fundProxy(desired.amount0, desired.amount1);
+
+        vm.startPrank(relayer);
+        (uint256 tokenId, uint128 liquidity,,) = mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+
+        assertGt(liquidity, 0, "Should successfully add liquidity when TWAP aligns with spot");
+        assertGt(tokenId, 0, "Should mint position NFT");
+    }
+
+    function _mockTwapObserve(int24 twapTick) internal {
+        // The TWAP calculation is: arithmeticMeanTick = (tickCumulatives[1] - tickCumulatives[0]) / secondsAgo
+        // So to get a specific twapTick: tickCumulatives[1] - tickCumulatives[0] = twapTick * secondsAgo
+        int56[] memory tickCumulatives = new int56[](2);
+        tickCumulatives[0] = 0;
+        tickCumulatives[1] = int56(twapTick) * int56(int32(86400)); // delta = twapTick * secondsAgo
+
+        uint160[] memory secondsPerLiquidityCumulativeX128s = new uint160[](2);
+        secondsPerLiquidityCumulativeX128s[0] = 0;
+        secondsPerLiquidityCumulativeX128s[1] = 1;
+
+        // Build the exact calldata that will be used
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = 86400; // 1 day - matches twapSecondsAgo config
+        secondsAgos[1] = 0;
+
+        // Mock the exact call that will be made
+        vm.mockCall(
+            _getPool(),
+            abi.encodeCall(IUniswapV3PoolLike.observe, (secondsAgos)),
+            abi.encode(tickCumulatives, secondsPerLiquidityCumulativeX128s)
+        );
+    }
+}
+
 contract MainnetControllerAddLiquidityE2EUniswapV3Test is UniswapV3TestBase {
     function _addLiquidityAndValidate(
         uint256 currentTokenId,

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -11,6 +11,8 @@ import { SafeERC20 }          from "openzeppelin-contracts/contracts/token/ERC20
 import { INonfungiblePositionManager, IUniswapV3PoolLike } from "../../src/libraries/UniswapV3Lib.sol";
 import { UniswapV3Lib }                                    from "../../src/libraries/UniswapV3Lib.sol";
 
+import { ISwapRouter } from "../../src/interfaces/UniswapV3Interfaces.sol";
+
 import { UniV3Utils } from "lib/dss-allocator/test/funnels/UniV3Utils.sol";
 import { FullMath }   from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
 import { TickMath }   from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
@@ -71,10 +73,10 @@ contract UniswapV3TestBase is ForkTestBase {
         rateLimits.setRateLimitData(uniswapV3_DaiUsdcPool_DaiSwapKey,   1_000_000e18, uint256(1_000_000e18) / 1 days);
         rateLimits.setRateLimitData(uniswapV3_DaiUsdcPool_UsdcSwapKey,  1_000_000e6,  uint256(1_000_000e6)  / 1 days);
 
-        rateLimits.setRateLimitData(uniswapV3_UsdcUsdtPool_UsdcAddLiquidityKey, 1_000_000e6,  uint256(1_000_000e6) / 1 days);
-        rateLimits.setRateLimitData(uniswapV3_UsdcUsdtPool_UsdtAddLiquidityKey, 1_000_000e6,  uint256(1_000_000e6) / 1 days);
+        rateLimits.setRateLimitData(uniswapV3_UsdcUsdtPool_UsdcAddLiquidityKey, 1_000_000e6,  uint256(1_000_000e6)  / 1 days);
+        rateLimits.setRateLimitData(uniswapV3_UsdcUsdtPool_UsdtAddLiquidityKey, 1_000_000e6,  uint256(1_000_000e6)  / 1 days);
         rateLimits.setRateLimitData(uniswapV3_DaiUsdcPool_DaiAddLiquidityKey,   1_000_000e18, uint256(1_000_000e18) / 1 days);
-        rateLimits.setRateLimitData(uniswapV3_DaiUsdcPool_UsdcAddLiquidityKey,  1_000_000e6,  uint256(1_000_000e6) / 1 days);
+        rateLimits.setRateLimitData(uniswapV3_DaiUsdcPool_UsdcAddLiquidityKey,  1_000_000e6,  uint256(1_000_000e6)  / 1 days);
 
         rateLimits.setRateLimitData(uniswapV3_UsdcUsdtPool_UsdcRemoveLiquidityKey, 1_000_000e6,  uint256(1_000_000e6)  / 1 days);
         rateLimits.setRateLimitData(uniswapV3_UsdcUsdtPool_UsdtRemoveLiquidityKey, 1_000_000e6,  uint256(1_000_000e6)  / 1 days);
@@ -85,7 +87,7 @@ contract UniswapV3TestBase is ForkTestBase {
         mainnetController.setMaxSlippage(_getPool(), 0.98e18);
         // All trades must have no more than 200 ticks impact on the pool. For most stablecoin pools, a tick is 1bps
         mainnetController.setUniswapV3PoolMaxTickDelta(_getPool(), 200);
-        mainnetController.setUniswapV3TwapSecondsAgo(_getPool(), 1 days);
+        mainnetController.setUniswapV3TwapSecondsAgo(_getPool(),   1 days);
 
         vm.stopPrank();
 
@@ -119,7 +121,7 @@ contract UniswapV3TestBase is ForkTestBase {
         return UNISWAP_V3_USDC_USDT_POOL;
     }
 
-    function _getBlock() internal pure override returns (uint256) {
+    function _getBlock() internal pure virtual override returns (uint256) {
         return 23677743;  // Oct 28, 2025
     }
 
@@ -1630,5 +1632,115 @@ contract MainnetControllerRemoveLiquidityE2EUniswapV3DaiUsdcTest is MainnetContr
             uniswapV3_DaiUsdcPool_DaiRemoveLiquidityKey,
             uniswapV3_DaiUsdcPool_UsdcRemoveLiquidityKey
         );
+    }
+}
+
+// Adapted from Certora's findings: https://gist.github.com/3docSec/616413000a6ebb154211db74589e0782
+contract MainnetControllerSwapSandwichAttackTest is UniswapV3TestBase {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function _getPool() internal pure override returns (address) {
+        return UNISWAP_V3_DAI_USDC_POOL;
+    }
+
+    function _getBlock() internal pure override returns (uint256) {
+        return 22181045; // Apr 02, 2025
+    }
+    
+    function test_uniswapV3_sandwichRisk_withoutTWAP() public {
+        address pool                    = _getPool();
+        IUniswapV3PoolLike poolContract = IUniswapV3PoolLike(pool);
+        uint24 fee                      = poolContract.fee();
+
+        // Victim intends to swap 1M USDC -> DAI via the controller.
+        uint256 victimAmountIn = 1_000_000e6;
+
+        // Configure rate limits and Uniswap params for this pool.
+        bytes32 swapKey = RateLimitHelpers.makeAssetDestinationKey(
+            mainnetController.LIMIT_UNISWAP_V3_SWAP(),
+            address(usdc),
+            pool
+        );
+
+        vm.startPrank(GROVE_PROXY);
+        rateLimits.setUnlimitedRateLimitData(swapKey);
+        // Allow up to ~1% local slippage
+        mainnetController.setMaxSlippage(pool, 0.99e18);
+        // Allow a moderate max tick move per swap.
+        mainnetController.setUniswapV3PoolMaxTickDelta(pool, 500);
+        vm.stopPrank();
+
+        // Front-run leg: USDC -> DAI in the same direction as the forthcoming victim swap.
+        uint256 attackerInitialUsdc = 10_000_000e6;
+        deal(address(usdc), address(this), attackerInitialUsdc);
+        IERC20(address(usdc)).approve(UNISWAP_V3_ROUTER, attackerInitialUsdc);
+
+        ISwapRouter.ExactInputSingleParams memory frontParams = ISwapRouter.ExactInputSingleParams({
+            tokenIn           : address(usdc),
+            tokenOut          : address(dai),
+            fee               : fee,
+            recipient         : address(this),
+            amountIn          : attackerInitialUsdc,
+            amountOutMinimum  : 0,
+            sqrtPriceLimitX96 : 0
+        });
+
+        ISwapRouter(UNISWAP_V3_ROUTER).exactInputSingle(frontParams);
+
+        // Victim swap via the controller at the manipulated spot price (USDC -> DAI).
+        deal(address(usdc), address(almProxy), victimAmountIn);
+
+        uint256 victimDaiBalanceBefore = dai.balanceOf(address(almProxy));
+
+        vm.startPrank(relayer);
+        uint256[] memory minAmountOut = new uint256[](8);
+
+        minAmountOut[0] = 5.2e13;
+        minAmountOut[1] = 5.1e13;
+        minAmountOut[2] = 4.95e13;
+        minAmountOut[3] = 4.82e13;
+        minAmountOut[4] = 4.70e13;
+        minAmountOut[5] = 4.60e13;
+        minAmountOut[6] = 4.48e13;
+        minAmountOut[7] = 3.69e13;
+
+        for (uint256 i = 0; i < 1; i++) {
+            uint256 amountIn = usdc.balanceOf(address(almProxy));
+
+            // This should be triggered since we calculate `sqrtPriceLimitX96` using the TWAP
+            vm.expectRevert(bytes("SPL"));
+            mainnetController.swapUniswapV3(
+                pool,
+                address(usdc),
+                amountIn,
+                minAmountOut[i],
+                500
+            );
+        }
+        vm.stopPrank();
+
+        // Back-run leg: attacker sells all received DAI back to USDC after victim restores price.
+        uint256 attackerDaiBalance = dai.balanceOf(address(this));
+        IERC20(address(dai)).approve(UNISWAP_V3_ROUTER, attackerDaiBalance);
+
+        ISwapRouter.ExactInputSingleParams memory backParams = ISwapRouter.ExactInputSingleParams({
+            tokenIn           : address(dai),
+            tokenOut          : address(usdc),
+            fee               : fee,
+            recipient         : address(this),
+            amountIn          : attackerDaiBalance,
+            amountOutMinimum  : 0,
+            sqrtPriceLimitX96 : 0
+        });
+
+        ISwapRouter(UNISWAP_V3_ROUTER).exactInputSingle(backParams);
+
+        uint256 attackerFinalUsdc = usdc.balanceOf(address(this));
+
+        assertLe(attackerFinalUsdc,                attackerInitialUsdc,               "attacker should have lower or same balance of USDC as before attack");
+        assertEq(victimAmountIn,                   usdc.balanceOf(address(almProxy)), "proxy should have same balance of USDC as before attack");
+        assertEq(dai.balanceOf(address(almProxy)), victimDaiBalanceBefore,            "proxy should have same balance of DAI as before attack");
     }
 }

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -389,6 +389,9 @@ contract ForeignControllerAdminTestBase is UnitTestBase {
     event MaxSlippageSet(address indexed pool, uint256 maxSlippage);
     event LayerZeroRecipientSet(uint32 indexed destinationDomain, bytes32 layerZeroRecipient);
     event MintRecipientSet(uint32 indexed destinationDomain, bytes32 mintRecipient);
+    event UniswapV3PoolMaxTickDeltaSet(address indexed pool, uint24 maxTickDelta);
+    event UniswapV3PoolLowerTickUpdated(address indexed pool, int24 lowerTick);
+    event UniswapV3PoolUpperTickUpdated(address indexed pool, int24 upperTick);
 
     ForeignController foreignController;
 
@@ -542,6 +545,207 @@ contract ForeignControllerSetMaxSlippageTests is ForeignControllerAdminTestBase 
         foreignController.setMaxSlippage(pool, 0.02e18);
 
         assertEq(foreignController.maxSlippages(pool), 0.02e18);
+    }
+
+}
+
+contract ForeignControllerSetUniswapV3PoolMaxTickDeltaTests is ForeignControllerAdminTestBase {
+
+    function test_setUniswapV3PoolMaxTickDelta_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 1000);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 1000);
+    }
+
+    function test_setUniswapV3PoolMaxTickDelta_zeroMaxTickDelta() public {
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 0);
+    }
+
+    function test_setUniswapV3PoolMaxTickDelta_exceedsMaxTickDelta() public {
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 887273); // MAX_TICK_DELTA + 1
+    }
+
+    function test_setUniswapV3PoolMaxTickDelta() public {
+        address pool = makeAddr("pool");
+
+        ( uint24 maxTickDelta,, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(uint256(maxTickDelta), 0);
+
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolMaxTickDeltaSet(pool, 1000);
+        foreignController.setUniswapV3PoolMaxTickDelta(pool, 1000);
+
+        ( maxTickDelta,, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(uint256(maxTickDelta), 1000);
+
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolMaxTickDeltaSet(pool, 887272); // MAX_TICK_DELTA
+        foreignController.setUniswapV3PoolMaxTickDelta(pool, 887272);
+
+        ( maxTickDelta,, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(uint256(maxTickDelta), 887272);
+    }
+
+}
+
+contract ForeignControllerSetUniswapV3AddLiquidityLowerTickBoundTests is ForeignControllerAdminTestBase {
+
+    function test_setUniswapV3AddLiquidityLowerTickBound_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -1000);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -1000);
+    }
+
+    function test_setUniswapV3AddLiquidityLowerTickBound_belowMinTick() public {
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -887273); // MIN_TICK - 1
+    }
+
+    function test_setUniswapV3AddLiquidityLowerTickBound_atOrAboveUpperTick() public {
+        address pool = makeAddr("pool");
+
+        // First set an upper tick bound
+        vm.prank(admin);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
+
+        // Try to set lower tick at or above the upper tick
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
+
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, 1001);
+    }
+
+    function test_setUniswapV3AddLiquidityLowerTickBound() public {
+        address pool = makeAddr("pool");
+
+        // First set an upper tick bound so we have room to set lower
+        vm.prank(admin);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 5000);
+
+        (, UniswapV3Lib.Tick memory tickBounds, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, 0);
+        assertEq(tickBounds.upper, 5000);
+
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolLowerTickUpdated(pool, -1000);
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, -1000);
+
+        (, tickBounds, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, -1000);
+
+        // Can set at MIN_TICK
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolLowerTickUpdated(pool, -887272);
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, -887272);
+
+        (, tickBounds, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, -887272);
+    }
+
+}
+
+contract ForeignControllerSetUniswapV3AddLiquidityUpperTickBoundTests is ForeignControllerAdminTestBase {
+
+    function test_setUniswapV3AddLiquidityUpperTickBound_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 1000);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 1000);
+    }
+
+    function test_setUniswapV3AddLiquidityUpperTickBound_aboveMaxTick() public {
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 887273); // MAX_TICK + 1
+    }
+
+    function test_setUniswapV3AddLiquidityUpperTickBound_atOrBelowLowerTick() public {
+        address pool = makeAddr("pool");
+
+        // First set a lower tick bound
+        vm.prank(admin);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 2000);
+        vm.prank(admin);
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
+
+        // Try to set upper tick at or below the lower tick
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
+
+        vm.prank(admin);
+        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 999);
+    }
+
+    function test_setUniswapV3AddLiquidityUpperTickBound() public {
+        address pool = makeAddr("pool");
+
+        (, UniswapV3Lib.Tick memory tickBounds, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, 0);
+        assertEq(tickBounds.upper, 0);
+
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolUpperTickUpdated(pool, 1000);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
+
+        (, tickBounds, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, 0);
+        assertEq(tickBounds.upper, 1000);
+
+        // Can set at MAX_TICK
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolUpperTickUpdated(pool, 887272);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 887272);
+
+        (, tickBounds, ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.upper, 887272);
     }
 
 }

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.21;
 
 import { ForeignController } from "../../../src/ForeignController.sol";
 import { MainnetController } from "../../../src/MainnetController.sol";
+import { UniswapV3Lib }      from "../../../src/libraries/UniswapV3Lib.sol";
 
 import { MockDaiUsds } from "../mocks/MockDaiUsds.sol";
 import { MockPSM }     from "../mocks/MockPSM.sol";
@@ -15,6 +16,9 @@ contract MainnetControllerAdminTestBase is UnitTestBase {
     event LayerZeroRecipientSet(uint32 indexed destinationDomain, bytes32 layerZeroRecipient);
     event MaxSlippageSet(address indexed pool, uint256 maxSlippage);
     event MintRecipientSet(uint32 indexed destinationDomain, bytes32 mintRecipient);
+    event UniswapV3PoolMaxTickDeltaSet(address indexed pool, uint24 maxTickDelta);
+    event UniswapV3PoolLowerTickUpdated(address indexed pool, int24 lowerTick);
+    event UniswapV3PoolUpperTickUpdated(address indexed pool, int24 upperTick);
 
     bytes32 layerZeroRecipient1 = bytes32(uint256(uint160(makeAddr("layerZeroRecipient1"))));
     bytes32 layerZeroRecipient2 = bytes32(uint256(uint160(makeAddr("layerZeroRecipient2"))));
@@ -174,6 +178,207 @@ contract MainnetControllerSetMaxSlippageTests is MainnetControllerAdminTestBase 
         mainnetController.setMaxSlippage(pool, 0.02e18);
 
         assertEq(mainnetController.maxSlippages(pool), 0.02e18);
+    }
+
+}
+
+contract MainnetControllerSetUniswapV3PoolMaxTickDeltaTests is MainnetControllerAdminTestBase {
+
+    function test_setUniswapV3PoolMaxTickDelta_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 1000);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 1000);
+    }
+
+    function test_setUniswapV3PoolMaxTickDelta_zeroMaxTickDelta() public {
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 0);
+    }
+
+    function test_setUniswapV3PoolMaxTickDelta_exceedsMaxTickDelta() public {
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 887273); // MAX_TICK_DELTA + 1
+    }
+
+    function test_setUniswapV3PoolMaxTickDelta() public {
+        address pool = makeAddr("pool");
+
+        ( uint24 maxTickDelta,, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(maxTickDelta, 0);
+
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolMaxTickDeltaSet(pool, 1000);
+        mainnetController.setUniswapV3PoolMaxTickDelta(pool, 1000);
+
+        ( maxTickDelta,, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(maxTickDelta, 1000);
+
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolMaxTickDeltaSet(pool, 887272); // MAX_TICK_DELTA
+        mainnetController.setUniswapV3PoolMaxTickDelta(pool, 887272);
+
+        ( maxTickDelta,, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(maxTickDelta, 887272);
+    }
+
+}
+
+contract MainnetControllerSetUniswapV3AddLiquidityLowerTickBoundTests is MainnetControllerAdminTestBase {
+
+    function test_setUniswapV3AddLiquidityLowerTickBound_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -1000);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -1000);
+    }
+
+    function test_setUniswapV3AddLiquidityLowerTickBound_belowMinTick() public {
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -887273); // MIN_TICK - 1
+    }
+
+    function test_setUniswapV3AddLiquidityLowerTickBound_atOrAboveUpperTick() public {
+        address pool = makeAddr("pool");
+
+        // First set an upper tick bound
+        vm.prank(admin);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
+
+        // Try to set lower tick at or above the upper tick
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
+
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, 1001);
+    }
+
+    function test_setUniswapV3AddLiquidityLowerTickBound() public {
+        address pool = makeAddr("pool");
+
+        // First set an upper tick bound so we have room to set lower
+        vm.prank(admin);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 5000);
+
+        (, UniswapV3Lib.Tick memory tickBounds, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, 0);
+        assertEq(tickBounds.upper, 5000);
+
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolLowerTickUpdated(pool, -1000);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, -1000);
+
+        (, tickBounds, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, -1000);
+
+        // Can set at MIN_TICK
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolLowerTickUpdated(pool, -887272);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, -887272);
+
+        (, tickBounds, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, -887272);
+    }
+
+}
+
+contract MainnetControllerSetUniswapV3AddLiquidityUpperTickBoundTests is MainnetControllerAdminTestBase {
+
+    function test_setUniswapV3AddLiquidityUpperTickBound_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 1000);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 1000);
+    }
+
+    function test_setUniswapV3AddLiquidityUpperTickBound_aboveMaxTick() public {
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 887273); // MAX_TICK + 1
+    }
+
+    function test_setUniswapV3AddLiquidityUpperTickBound_atOrBelowLowerTick() public {
+        address pool = makeAddr("pool");
+
+        // First set a lower tick bound
+        vm.prank(admin);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 2000);
+        vm.prank(admin);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
+
+        // Try to set upper tick at or below the lower tick
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
+
+        vm.prank(admin);
+        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 999);
+    }
+
+    function test_setUniswapV3AddLiquidityUpperTickBound() public {
+        address pool = makeAddr("pool");
+
+        (, UniswapV3Lib.Tick memory tickBounds, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, 0);
+        assertEq(tickBounds.upper, 0);
+
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolUpperTickUpdated(pool, 1000);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
+
+        (, tickBounds, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.lower, 0);
+        assertEq(tickBounds.upper, 1000);
+
+        // Can set at MAX_TICK
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolUpperTickUpdated(pool, 887272);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 887272);
+
+        (, tickBounds, ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(tickBounds.upper, 887272);
     }
 
 }

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -19,6 +19,7 @@ contract MainnetControllerAdminTestBase is UnitTestBase {
     event UniswapV3PoolMaxTickDeltaSet(address indexed pool, uint24 maxTickDelta);
     event UniswapV3PoolLowerTickUpdated(address indexed pool, int24 lowerTick);
     event UniswapV3PoolUpperTickUpdated(address indexed pool, int24 upperTick);
+    event UniswapV3PoolTwapSecondsAgoUpdated(address indexed pool, uint32 twapSecondsAgo);
 
     bytes32 layerZeroRecipient1 = bytes32(uint256(uint160(makeAddr("layerZeroRecipient1"))));
     bytes32 layerZeroRecipient2 = bytes32(uint256(uint160(makeAddr("layerZeroRecipient2"))));
@@ -383,6 +384,50 @@ contract MainnetControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Mainnet
 
 }
 
+contract MainnetControllerSetUniswapV3TwapSecondsAgoTests is MainnetControllerAdminTestBase {
+
+    function test_setUniswapV3TwapSecondsAgo_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), 300);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), 300);
+    }
+
+    function test_setUniswapV3TwapSecondsAgo() public {
+        address pool = makeAddr("pool");
+
+        (,, uint32 twapSecondsAgo ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(twapSecondsAgo, 0);
+
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolTwapSecondsAgoUpdated(pool, 300);
+        mainnetController.setUniswapV3TwapSecondsAgo(pool, 300);
+
+        (,, twapSecondsAgo ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(twapSecondsAgo, 300);
+
+        vm.prank(admin);
+        vm.expectEmit(address(mainnetController));
+        emit UniswapV3PoolTwapSecondsAgoUpdated(pool, 1800);
+        mainnetController.setUniswapV3TwapSecondsAgo(pool, 1800);
+
+        (,, twapSecondsAgo ) = mainnetController.uniswapV3PoolParams(pool);
+        assertEq(twapSecondsAgo, 1800);
+    }
+
+}
+
 
 contract ForeignControllerAdminTestBase is UnitTestBase {
 
@@ -392,6 +437,7 @@ contract ForeignControllerAdminTestBase is UnitTestBase {
     event UniswapV3PoolMaxTickDeltaSet(address indexed pool, uint24 maxTickDelta);
     event UniswapV3PoolLowerTickUpdated(address indexed pool, int24 lowerTick);
     event UniswapV3PoolUpperTickUpdated(address indexed pool, int24 upperTick);
+    event UniswapV3PoolTwapSecondsAgoUpdated(address indexed pool, uint32 twapSecondsAgo);
 
     ForeignController foreignController;
 
@@ -770,6 +816,50 @@ contract ForeignControllerSetMerklDistributorTests is ForeignControllerAdminTest
         vm.expectEmit(address(foreignController));
         emit MerklDistributorSet(makeAddr("merklDistributor"));
         foreignController.setMerklDistributor(makeAddr("merklDistributor"));
+    }
+
+}
+
+contract ForeignControllerSetUniswapV3TwapSecondsAgoTests is ForeignControllerAdminTestBase {
+
+    function test_setUniswapV3TwapSecondsAgo_unauthorizedAccount() public {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), 300);
+
+        vm.prank(freezer);
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            freezer,
+            DEFAULT_ADMIN_ROLE
+        ));
+        foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), 300);
+    }
+
+    function test_setUniswapV3TwapSecondsAgo() public {
+        address pool = makeAddr("pool");
+
+        (,, uint32 twapSecondsAgo ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(twapSecondsAgo, 0);
+
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolTwapSecondsAgoUpdated(pool, 300);
+        foreignController.setUniswapV3TwapSecondsAgo(pool, 300);
+
+        (,, twapSecondsAgo ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(twapSecondsAgo, 300);
+
+        vm.prank(admin);
+        vm.expectEmit(address(foreignController));
+        emit UniswapV3PoolTwapSecondsAgoUpdated(pool, 1800);
+        foreignController.setUniswapV3TwapSecondsAgo(pool, 1800);
+
+        (,, twapSecondsAgo ) = foreignController.uniswapV3PoolParams(pool);
+        assertEq(twapSecondsAgo, 1800);
     }
 
 }

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -403,6 +403,18 @@ contract MainnetControllerSetUniswapV3TwapSecondsAgoTests is MainnetControllerAd
         mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), 300);
     }
 
+    function test_setUniswapV3TwapSecondsAgo_outOfBounds() public {
+        vm.startPrank(admin);
+
+        vm.expectRevert("MainnetController/twap-seconds-ago-out-of-bounds");
+        mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), uint32(type(int32).max));
+
+        vm.expectRevert("MainnetController/twap-seconds-ago-out-of-bounds");
+        mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), type(uint32).max);
+
+        vm.stopPrank();
+    }
+
     function test_setUniswapV3TwapSecondsAgo() public {
         address pool = makeAddr("pool");
 
@@ -837,6 +849,18 @@ contract ForeignControllerSetUniswapV3TwapSecondsAgoTests is ForeignControllerAd
             DEFAULT_ADMIN_ROLE
         ));
         foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), 300);
+    }
+
+    function test_setUniswapV3TwapSecondsAgo_outOfBounds() public {
+        vm.startPrank(admin);
+
+        vm.expectRevert("ForeignController/twap-seconds-ago-out-of-bounds");
+        foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), uint32(type(int32).max));
+
+        vm.expectRevert("ForeignController/twap-seconds-ago-out-of-bounds");
+        foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), type(uint32).max);
+
+        vm.stopPrank();
     }
 
     function test_setUniswapV3TwapSecondsAgo() public {


### PR DESCRIPTION
Issues:

Certora: C-01
ChainSecurity: 5.1

 Core TWAP Protection (UniswapV3Lib.sol)
  - Added twapSecondsAgo parameter to UniswapV3PoolParams struct
  - Added _validateAddLiquidityMinAmounts() which:
    - Fetches the pool's TWAP tick using the configured lookback period
    - Calculates expected token amounts based on TWAP price and tick range
    - Validates that minAmount0 and minAmount1 meet the maxSlippage threshold relative to expected amounts
    - Enforces that if expected amount is 0 (tick range entirely above/below TWAP), the corresponding minAmount must also be 0

  New Uniswap V3 Oracle Libraries
  - UniV3OracleLib.sol - Oracle library for fetching TWAP from pool observations
  - UniV3UtilsLib.sol - Utility functions for liquidity/amount calculations (re-exports TickMath, LiquidityAmounts, FullMath)

  Controller Admin Functions
  - Added setUniswapV3TwapSecondsAgo(address pool, uint32 twapSecondsAgo) to both MainnetController and ForeignController
  - Added upper bound validation on twapSecondsAgo to prevent int32 overflow (~68 year max)

  Test Coverage
  - Added comprehensive unit tests for all new admin functions in Admin.t.sol
  - Added TWAP protection fork tests for both mainnet and base:
    - Reverts when spot price is manipulated (Uniswap's slippage check fails)
    - Reverts when TWAP is above tick range and minAmount0 != 0
    - Reverts when TWAP is below tick range and minAmount1 != 0
    - Reverts when minAmount0 is below TWAP-calculated threshold
    - Reverts when minAmount1 is below TWAP-calculated threshold
    - Succeeds when price matches TWAP (normal conditions)

  Build Configuration
  - Added [profile.ci] section to foundry.toml to fix CI lint errors by inheriting default lint ignore settings