### PR TITLE
fix: Add missing remappings for dss-allocator and spark-psm

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -17,7 +17,9 @@ remappings = [
     '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/',
     '@layerzerolabs/lz-evm-messagelib-v2/=lib/layerzero-v2/packages/layerzero-v2/evm/messagelib/',
     'solidity-bytes-utils/=lib/solidity-bytes-utils/',
-    'forge-std/=lib/forge-std/src/'
+    'forge-std/=lib/forge-std/src/',
+    'dss-allocator/=lib/dss-allocator/',
+    'spark-psm/=lib/spark-psm/'
 ]
 
 [fuzz]


### PR DESCRIPTION
Added missing Foundry remappings to resolve CI build failures. The dss-allocator and spark-psm libraries use 'src/' import paths that require explicit remappings in foundry.toml.