### PR TITLE
chore: ChainSecurity initial feedback [5.3, 5.5, 7.3, 7.5]

### DIFF
--- a/src/interfaces/UniswapV3Interfaces.sol
+++ b/src/interfaces/UniswapV3Interfaces.sol
@@ -23,6 +23,8 @@ interface IUniswapV3PoolLike {
     function token0() external view returns (address);
     function token1() external view returns (address);
     function fee() external view returns (uint24);
+    function tickSpacing() external view returns (int24);
+
     function slot0()
         external
         view

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.21;
 
 import { IERC20 }         from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
-import { IERC20Metadata } from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import { ERC20Lib } from "./common/ERC20Lib.sol";
 import { MathLib }  from "./common/MathLib.sol";
@@ -85,7 +84,7 @@ library UniswapV3Lib {
     /*** External functions                                                                     ***/
     /**********************************************************************************************/
 
-    // Rate limit decreased by value of token1
+    // Rate limit decreased by value of tokenIn
     function swap(UniV3Context calldata context, SwapParams calldata params) external returns (uint256 amountOut) {
         require(params.maxSlippage > 0,                                 "UniswapV3Lib/max-slippage-not-set");
         require(params.tickDelta <= params.poolParams.swapMaxTickDelta, "UniswapV3Lib/invalid-max-tick-delta");
@@ -266,6 +265,12 @@ library UniswapV3Lib {
     }
 
     //-- Add liquidity functions
+
+    function _validateAddLiquidityParams(UniV3Context calldata context, AddLiquidityParams calldata params) internal view {
+        require(params.tick.lower >= params.tickBounds.lower, "UniswapV3Lib/invalid-tick-lower");
+        require(params.tick.upper <= params.tickBounds.upper, "UniswapV3Lib/invalid-tick-upper");
+    }
+
     function _mintLiquidity(UniV3Context calldata context, AddLiquidityParams calldata params)
         internal
         returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)
@@ -308,7 +313,7 @@ library UniswapV3Lib {
         require(params.positionManager.ownerOf(params.tokenId) == address(context.proxy), "UniswapV3Lib/proxy-does-not-own-token-id");
 
 
-        (, , , int24 tickLower, int24 tickUpper, ) = _fetchPositionData(params.tokenId, params.positionManager);
+        (address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, ) = _fetchPositionData(params.tokenId, params.positionManager);
 
         require(params.tick.lower >= tickLower, "UniswapV3Lib/invalid-tick-lower");
         require(params.tick.upper <= tickUpper, "UniswapV3Lib/invalid-tick-upper");

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -265,12 +265,6 @@ library UniswapV3Lib {
     }
 
     //-- Add liquidity functions
-
-    function _validateAddLiquidityParams(UniV3Context calldata context, AddLiquidityParams calldata params) internal view {
-        require(params.tick.lower >= params.tickBounds.lower, "UniswapV3Lib/invalid-tick-lower");
-        require(params.tick.upper <= params.tickBounds.upper, "UniswapV3Lib/invalid-tick-upper");
-    }
-
     function _mintLiquidity(UniV3Context calldata context, AddLiquidityParams calldata params)
         internal
         returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)
@@ -312,8 +306,11 @@ library UniswapV3Lib {
     {
         require(params.positionManager.ownerOf(params.tokenId) == address(context.proxy), "UniswapV3Lib/proxy-does-not-own-token-id");
 
-
         (address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, ) = _fetchPositionData(params.tokenId, params.positionManager);
+
+        IUniswapV3PoolLike pool = IUniswapV3PoolLike(context.pool);
+
+        require(pool.token0() == token0 && pool.token1() == token1 && pool.fee() == fee, "UniswapV3Lib/invalid-pool");
 
         require(params.tick.lower >= tickLower, "UniswapV3Lib/invalid-tick-lower");
         require(params.tick.upper <= tickUpper, "UniswapV3Lib/invalid-tick-upper");

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -118,6 +118,9 @@ library UniswapV3Lib {
         require(params.maxSlippage > 0,     "UniswapV3Lib/max-slippage-not-set");
         require(params.twapSecondsAgo != 0, "UniswapV3Lib/zero-twap-seconds");
 
+        require(params.tick.lower >= params.tickBounds.lower, "UniswapV3Lib/lower-tick-outside-bounds");
+        require(params.tick.upper <= params.tickBounds.upper, "UniswapV3Lib/upper-tick-outside-bounds");
+
         IUniswapV3PoolLike pool = IUniswapV3PoolLike(context.pool);
 
         address token0 = pool.token0();
@@ -269,8 +272,6 @@ library UniswapV3Lib {
         internal
         returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)
     {
-        require(params.tick.lower >= params.tickBounds.lower, "UniswapV3Lib/invalid-tick-lower");
-        require(params.tick.upper <= params.tickBounds.upper, "UniswapV3Lib/invalid-tick-upper");
 
         IUniswapV3PoolLike pool = IUniswapV3PoolLike(context.pool);
 

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -275,6 +275,12 @@ library UniswapV3Lib {
 
         IUniswapV3PoolLike pool = IUniswapV3PoolLike(context.pool);
 
+        int24 tickSpacing = pool.tickSpacing();
+
+        // Validate that lower and upper ticks are correctly spaced
+        require(params.tick.lower % tickSpacing == 0, "UniswapV3Lib/invalid-lower-tick");
+        require(params.tick.upper % tickSpacing == 0, "UniswapV3Lib/invalid-upper-tick");
+
         INonfungiblePositionManager.MintParams memory mintParams
             = INonfungiblePositionManager.MintParams({
                 token0         : pool.token0(),

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0;
 
 import { IERC20 }                 from "forge-std/interfaces/IERC20.sol";
 import { IERC20Metadata } from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { IERC721 }        from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 
 import { UniV3Utils } from "lib/dss-allocator/test/funnels/UniV3Utils.sol";
 import { FullMath }   from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
@@ -64,8 +65,12 @@ contract UniswapV3TestBase is ForkTestBase {
     uint8   internal token0Decimals;
     int24   internal initTick;
 
+    address internal stranger;
+
     function setUp() public virtual override  {
         super.setUp();
+
+        stranger = makeAddr("stranger");
 
         ausdBase  = IERC20(address(new ERC20Mock()));
 
@@ -352,7 +357,6 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
     }
 
     function _mintExternalPosition() internal returns (uint256 tokenId) {
-        address stranger = makeAddr("stranger-lp");
         uint256 amount0 = 5 * 10 ** uint256(token0Decimals);
         uint8 token1Decimals = IERC20Metadata(address(token1)).decimals();
         uint256 amount1 = 5 * 10 ** uint256(token1Decimals);
@@ -591,6 +595,34 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
                 amount0: amount0 * 98 / 100,
                 amount1: amount1 * 98 / 100
             }),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addliquidityUniswapV3_invalidPoolForPosition() public {
+        // Set arbitrary value
+        vm.prank(GROVE_EXECUTOR);
+        foreignController.setMaxSlippage(usdsAusdPool, 99 * 1e18);
+
+        // Mint a USDS-USDC position and transfer it to the relayer
+        uint256 usdsUsdcTokenId = _mintExternalPosition();
+
+        vm.prank(stranger);
+        IERC721(UNISWAP_V3_POSITION_MANAGER).transferFrom(stranger, address(almProxy), usdsUsdcTokenId);
+
+        vm.warp(block.timestamp + 1 hours);
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
+            = _prepareDefaultAddLiquidity();
+
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("UniswapV3Lib/invalid-pool");
+        foreignController.addLiquidityUniswapV3(
+            usdsAusdPool,
+            usdsUsdcTokenId, // USDS-USDC pool token ID
+            tick,
+            desired,
+            min,
             block.timestamp + 1 hours
         );
         vm.stopPrank();
@@ -1207,7 +1239,6 @@ contract ForeignControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
     }
 
     function _mintExternalPosition() internal returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) {
-        address stranger = makeAddr("stranger-remove-lp");
         UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
 
         deal(address(token0), stranger, desired.amount0);

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -453,7 +453,7 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
         tick.lower = initTick - 2000;
 
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("UniswapV3Lib/invalid-tick-lower");
+        vm.expectRevert("UniswapV3Lib/lower-tick-outside-bounds");
         foreignController.addLiquidityUniswapV3(
             _getPool(),
             0,
@@ -471,7 +471,7 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
         tick.upper = initTick + 2000;
 
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("UniswapV3Lib/invalid-tick-upper");
+        vm.expectRevert("UniswapV3Lib/upper-tick-outside-bounds");
         foreignController.addLiquidityUniswapV3(
             _getPool(),
             0,
@@ -600,10 +600,14 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
         vm.stopPrank();
     }
 
-    function test_addliquidityUniswapV3_invalidPoolForPosition() public {
-        // Set arbitrary value
-        vm.prank(GROVE_EXECUTOR);
-        foreignController.setMaxSlippage(usdsAusdPool, 99 * 1e18);
+    function test_addLiquidityUniswapV3_invalidPoolForPosition() public {
+        // Set arbitrary values
+        vm.startPrank(GROVE_EXECUTOR);
+        foreignController.setMaxSlippage(usdsAusdPool, 0.000001 * 1e18);
+        foreignController.setUniswapV3TwapSecondsAgo(usdsAusdPool, 1 seconds);
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(usdsAusdPool, -100000);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(usdsAusdPool, 100000);
+        vm.stopPrank();
 
         // Mint a USDS-USDC position and transfer it to the relayer
         uint256 usdsUsdcTokenId = _mintExternalPosition();
@@ -612,17 +616,90 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
         IERC721(UNISWAP_V3_POSITION_MANAGER).transferFrom(stranger, address(almProxy), usdsUsdcTokenId);
 
         vm.warp(block.timestamp + 1 hours);
-        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
-            = _prepareDefaultAddLiquidity();
 
         vm.startPrank(ALM_RELAYER);
         vm.expectRevert("UniswapV3Lib/invalid-pool");
         foreignController.addLiquidityUniswapV3(
             usdsAusdPool,
             usdsUsdcTokenId, // USDS-USDC pool token ID
+            UniswapV3Lib.Tick({
+                lower: -10000,
+                upper: 10000
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 1,
+                amount1: 1
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 0,
+                amount1: 0
+            }),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addLiquidityUniswapV3_failsAfterLowerTickBoundChanges() public {
+        // Create new default position
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, )
+            = _prepareDefaultAddLiquidity();
+
+        vm.prank(ALM_RELAYER);
+        (uint256 tokenId, , ,) = foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
             tick,
             desired,
-            min,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+
+        // Change tick bounds
+        vm.prank(GROVE_EXECUTOR);
+        foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), tick.lower + 100);
+
+        // Adding liquidity with the same tick bounds before the change should fail
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("UniswapV3Lib/lower-tick-outside-bounds");
+        foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            tokenId,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addLiquidityUniswapV3_failsAfterUpperTickBoundChanges() public {
+        // Create new default position
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, )
+            = _prepareDefaultAddLiquidity();
+
+        vm.prank(ALM_RELAYER);
+        (uint256 tokenId, , ,) = foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
+            block.timestamp + 1 hours
+        );
+
+        // Change tick bounds
+        vm.prank(GROVE_EXECUTOR);
+        foreignController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), tick.upper - 100);
+
+        // Adding liquidity with the same tick bounds before the change should fail
+        vm.startPrank(ALM_RELAYER);
+        vm.expectRevert("UniswapV3Lib/upper-tick-outside-bounds");
+        foreignController.addLiquidityUniswapV3(
+            _getPool(),
+            tokenId,
+            tick,
+            desired,
+            _minLiquidityPosition(desired.amount0, desired.amount1),
             block.timestamp + 1 hours
         );
         vm.stopPrank();

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.0;
 
-import { IERC20 }                 from "forge-std/interfaces/IERC20.sol";
+import { IERC20 }         from "forge-std/interfaces/IERC20.sol";
 import { IERC20Metadata } from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IERC721 }        from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -7,6 +7,7 @@ import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 import { IERC20Metadata }     from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IERC20 as IERC20OZ } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 }          from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC721 }            from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 
 import { INonfungiblePositionManager, IUniswapV3PoolLike } from "../../src/libraries/UniswapV3Lib.sol";
 import { UniswapV3Lib }                                    from "../../src/libraries/UniswapV3Lib.sol";
@@ -50,8 +51,12 @@ contract UniswapV3TestBase is ForkTestBase {
     int24              internal initTick;
     int24              internal tickSpacing;
 
+    address internal stranger;
+
     function setUp() public virtual override  {
         super.setUp();
+
+        stranger = makeAddr("stranger");
 
         uniswapV3_UsdcUsdtPool_UsdcSwapKey            = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(),     address(usdc), UNISWAP_V3_USDC_USDT_POOL);
         uniswapV3_UsdcUsdtPool_UsdtSwapKey            = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(),     address(usdt), UNISWAP_V3_USDC_USDT_POOL);
@@ -417,7 +422,6 @@ contract MainnetControllerSwapUniswapV3SuccessTests is UniswapV3TestBase {
     }
 }
 
-
 contract MainnetControllerE2EUniswapV3Test is UniswapV3TestBase {
     function _e2e_swapUniswapV3(uint256 swapAmount, IERC20 tokenIn, IERC20 tokenOut, bytes32 swapKey) internal {
         deal(address(tokenIn), address(almProxy), swapAmount);
@@ -591,7 +595,6 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
     }
 
     function _mintExternalPosition() internal returns (uint256 tokenId) {
-        address stranger = makeAddr("stranger-lp");
         uint256 amount0 = 5 * 10 ** uint256(token0Decimals);
         uint8 token1Decimals = IERC20Metadata(address(token1)).decimals();
         uint256 amount1 = 5 * 10 ** uint256(token1Decimals);
@@ -909,6 +912,34 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
                 amount0: amount0 * 98 / 100,
                 amount1: amount1 * 98 / 100
             }),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addliquidityUniswapV3_invalidPoolForPosition() public {
+        // Set arbitrary value
+        vm.prank(GROVE_PROXY);
+        mainnetController.setMaxSlippage(UNISWAP_V3_DAI_USDC_POOL, 99 * 1e18);
+
+        // Mint a USDC-USDT position and transfer it to the relayer
+        uint256 usdcUsdtTokenId = _mintExternalPosition();
+
+        vm.prank(stranger);
+        IERC721(UNISWAP_V3_POSITION_MANAGER).transferFrom(stranger, address(almProxy), usdcUsdtTokenId);
+
+        vm.warp(block.timestamp + 1 hours);
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
+            = _prepareDefaultAddLiquidity();
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/invalid-pool");
+        mainnetController.addLiquidityUniswapV3(
+            UNISWAP_V3_DAI_USDC_POOL,
+            usdcUsdtTokenId, // USDC-UgSDT pool token ID
+            tick,
+            desired,
+            min,
             block.timestamp + 1 hours
         );
         vm.stopPrank();
@@ -1341,7 +1372,6 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
     }
 
     function _mintExternalPosition() internal returns (uint256 tokenId_, uint128 liquidity_, uint256 amount0_, uint256 amount1_) {
-        address stranger = makeAddr("stranger-remove-lp");
         UniswapV3Lib.TokenAmounts memory desired = _defaultDesiredPosition();
 
         deal(address(token0), stranger, desired.amount0);

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -18,10 +18,6 @@ import { UniV3Utils } from "lib/dss-allocator/test/funnels/UniV3Utils.sol";
 import { FullMath }   from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
 import { TickMath }   from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
 
-interface IUniswapV3PoolLikeTickSpacing is IUniswapV3PoolLike {
-    function tickSpacing() external view returns (int24);
-}
-
 contract UniswapV3TestBase is ForkTestBase {
     address constant UNISWAP_V3_USDC_USDT_POOL   = 0x3416cF6C708Da44DB2624D63ea0AAef7113527C6;
     address constant UNISWAP_V3_DAI_USDC_POOL    = 0x6c6Bc977E13Df9b0de53b251522280BB72383700;
@@ -102,7 +98,7 @@ contract UniswapV3TestBase is ForkTestBase {
         poolFee            = pool.fee();
         token0Decimals     = IERC20Metadata(address(token0)).decimals();
         (, initTick, ,,,,) = pool.slot0();
-        tickSpacing        = IUniswapV3PoolLikeTickSpacing(address(pool)).tickSpacing();
+        tickSpacing        = IUniswapV3PoolLike(address(pool)).tickSpacing();
 
         vm.startPrank(GROVE_PROXY);
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), initTick - 1000);
@@ -1017,6 +1013,72 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
             tick,
             desired,
             min,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addLiquidityUniswapV3_failsIfLowerTickNotMultipleOfSpacing() public {
+        vm.startPrank(GROVE_PROXY);
+        mainnetController.setMaxSlippage(UNISWAP_V3_DAI_USDC_POOL, 0.000001 * 1e18);
+        mainnetController.setUniswapV3TwapSecondsAgo(UNISWAP_V3_DAI_USDC_POOL, 1 seconds);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(UNISWAP_V3_DAI_USDC_POOL, -100000);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(UNISWAP_V3_DAI_USDC_POOL, 100000);
+        vm.stopPrank();
+
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
+            = _prepareDefaultAddLiquidity();
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/invalid-lower-tick");
+        mainnetController.addLiquidityUniswapV3(
+            UNISWAP_V3_DAI_USDC_POOL,
+            0,
+            UniswapV3Lib.Tick({
+                lower: _toSpacedTick(-123), // invalid tick spacing
+                upper: _toSpacedTick(10000)
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 1,
+                amount1: 1
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 0,
+                amount1: 0
+            }),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addLiquidityUniswapV3_failsIfUpperTickNotMultipleOfSpacing() public {
+        vm.startPrank(GROVE_PROXY);
+        mainnetController.setMaxSlippage(UNISWAP_V3_DAI_USDC_POOL, 0.000001 * 1e18);
+        mainnetController.setUniswapV3TwapSecondsAgo(UNISWAP_V3_DAI_USDC_POOL, 1 seconds);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(UNISWAP_V3_DAI_USDC_POOL, -100000);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(UNISWAP_V3_DAI_USDC_POOL, 100000);
+        vm.stopPrank();
+
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
+            = _prepareDefaultAddLiquidity();
+
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/invalid-upper-tick");
+        mainnetController.addLiquidityUniswapV3(
+            UNISWAP_V3_DAI_USDC_POOL,
+            0,
+            UniswapV3Lib.Tick({
+                lower: _toSpacedTick(-10000),
+                upper: _toSpacedTick(123) // invalid tick spacing
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 1,
+                amount1: 1
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 0,
+                amount1: 0
+            }),
             block.timestamp + 1 hours
         );
         vm.stopPrank();

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -717,7 +717,7 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
         tick.lower = initTick - 2000;
 
         vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/invalid-tick-lower");
+        vm.expectRevert("UniswapV3Lib/lower-tick-outside-bounds");
         mainnetController.addLiquidityUniswapV3(
             _getPool(),
             0,
@@ -735,7 +735,7 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
         tick.upper = initTick + 2000;
 
         vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/invalid-tick-upper");
+        vm.expectRevert("UniswapV3Lib/upper-tick-outside-bounds");
         mainnetController.addLiquidityUniswapV3(
             _getPool(),
             0,
@@ -917,10 +917,14 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
         vm.stopPrank();
     }
 
-    function test_addliquidityUniswapV3_invalidPoolForPosition() public {
-        // Set arbitrary value
-        vm.prank(GROVE_PROXY);
-        mainnetController.setMaxSlippage(UNISWAP_V3_DAI_USDC_POOL, 99 * 1e18);
+    function test_addLiquidityUniswapV3_invalidPoolForPosition() public {
+        // Set arbitrary values
+        vm.startPrank(GROVE_PROXY);
+        mainnetController.setMaxSlippage(UNISWAP_V3_DAI_USDC_POOL, 0.000001 * 1e18);
+        mainnetController.setUniswapV3TwapSecondsAgo(UNISWAP_V3_DAI_USDC_POOL, 1 seconds);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(UNISWAP_V3_DAI_USDC_POOL, -100000);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(UNISWAP_V3_DAI_USDC_POOL, 100000);
+        vm.stopPrank();
 
         // Mint a USDC-USDT position and transfer it to the relayer
         uint256 usdcUsdtTokenId = _mintExternalPosition();
@@ -929,14 +933,87 @@ contract MainnetControllerAddLiquidityFailureTests is UniswapV3TestBase {
         IERC721(UNISWAP_V3_POSITION_MANAGER).transferFrom(stranger, address(almProxy), usdcUsdtTokenId);
 
         vm.warp(block.timestamp + 1 hours);
-        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
-            = _prepareDefaultAddLiquidity();
 
         vm.startPrank(relayer);
         vm.expectRevert("UniswapV3Lib/invalid-pool");
         mainnetController.addLiquidityUniswapV3(
             UNISWAP_V3_DAI_USDC_POOL,
-            usdcUsdtTokenId, // USDC-UgSDT pool token ID
+            usdcUsdtTokenId, // USDC-USDT pool token ID
+            UniswapV3Lib.Tick({
+                lower: _toSpacedTick(-10000),
+                upper: _toSpacedTick(10000)
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 1,
+                amount1: 1
+            }),
+            UniswapV3Lib.TokenAmounts({
+                amount0: 0,
+                amount1: 0
+            }),
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addLiquidityUniswapV3_failsAfterLowerTickBoundChanges() public {
+        // Create new default position
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
+            = _prepareDefaultAddLiquidity();
+
+        vm.prank(relayer);
+        (uint256 tokenId, , ,) = mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            min,
+            block.timestamp + 1 hours
+        );
+
+        // Change tick bounds
+        vm.prank(GROVE_PROXY);
+        mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), _toSpacedTick(tick.lower + 10));
+
+        // Adding liquidity with the same tick bounds before the change should fail
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/lower-tick-outside-bounds");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            tokenId,
+            tick,
+            desired,
+            min,
+            block.timestamp + 1 hours
+        );
+        vm.stopPrank();
+    }
+
+    function test_addLiquidityUniswapV3_failsAfterUpperTickBoundChanges() public {
+        // Create new default position
+        (UniswapV3Lib.Tick memory tick, UniswapV3Lib.TokenAmounts memory desired, UniswapV3Lib.TokenAmounts memory min)
+            = _prepareDefaultAddLiquidity();
+
+        vm.prank(relayer);
+        (uint256 tokenId, , ,) = mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            0,
+            tick,
+            desired,
+            min,
+            block.timestamp + 1 hours
+        );
+
+        // Change tick bounds
+        vm.prank(GROVE_PROXY);
+        mainnetController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), _toSpacedTick(tick.upper - 10));
+
+        // Adding liquidity with the same tick bounds before the change should fail
+        vm.startPrank(relayer);
+        vm.expectRevert("UniswapV3Lib/upper-tick-outside-bounds");
+        mainnetController.addLiquidityUniswapV3(
+            _getPool(),
+            tokenId,
             tick,
             desired,
             min,


### PR DESCRIPTION
Addresses initial feedback from ChainSecurity:

https://github.com/grove-labs/grove-alm-controller/pull/82/commits/4057979f16e45058979a779f82085e193738daa8
- [7.5] `IERC20Metadata` not being used
- [7.3] fixes description above `swap()`

Issue 5.3
https://github.com/grove-labs/grove-alm-controller/pull/82/commits/9731a21ac4bc56f219d3fc89e694ce614c3ed402
- Validates that tokenId belongs to the pool address being passed in when adding liquidity to an existing position

~Issue 5.2, L-03~
_Note:_ addressed in https://github.com/grove-labs/grove-alm-controller/pull/95
- Checks that an existing liquidity position is still within governance bounds when adding more liquidity to it

Issue 5.5
https://github.com/grove-labs/grove-alm-controller/pull/82/commits/a7cdad02e5971f274145f69f72b26a49faf0559a
- Validates ticks are multiples of the pool's tick spacing when minting new liquidity