### PR TITLE
Exclude `libraries/uniswap-v3` from coverage

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -39,4 +39,10 @@ arbitrum_one = { key = "${ARBISCAN_API_KEY}" }
 world_chain = { key = "${WORLD_CHAIN_API_KEY}", chain = 480, url = "https://worldchain-mainnet-explorer.alchemy.com/api" }
 unichain = { key = "${UNICHAIN_API_KEY}", chain = 130, url = "https://unichain.blockscout.com/api" }
 
+[coverage]
+exclude = [
+    "src/libraries/uniswap-v3/UniV3UtilsLib.sol",
+    "src/libraries/uniswap-v3/UniV3OracleLib.sol",
+]
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
This code was largely adapted from other audited sources