### PR TITLE
Certora M-02: Relayer can force losses onto Morpho vault depositors through reallocations

### DIFF
--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -820,7 +820,7 @@ contract ForeignController is AccessControl {
 
     function reallocateMorpho(address morphoVault, MarketAllocation[] calldata allocations)
         external
-        onlyRole(RELAYER)
+        onlyRole(DEFAULT_ADMIN_ROLE)
         rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_4626_DEPOSIT, morphoVault))
     {
         proxy.doCall(

--- a/test/spark-base-fork/MorphoAllocations.t.sol
+++ b/test/spark-base-fork/MorphoAllocations.t.sol
@@ -162,17 +162,19 @@ contract MorphoUpdateWithdrawQueueMorphoSuccessTests is MorphoTestBase {
 
 contract MorphoReallocateMorphoFailureTests is MorphoTestBase {
 
-    function test_reallocateMorpho_notRelayer() external {
+    function test_reallocateMorpho_notAdmin() external {
         vm.expectRevert(abi.encodeWithSignature(
             "AccessControlUnauthorizedAccount(address,bytes32)",
-            address(this),
-            RELAYER
+            relayer,
+            DEFAULT_ADMIN_ROLE
         ));
+
+        vm.prank(relayer);
         foreignController.reallocateMorpho(address(morphoVault), new MarketAllocation[](0));
     }
 
     function test_reallocateMorpho_invalidVault() external {
-        vm.prank(relayer);
+        vm.prank(Base.SPARK_EXECUTOR);
         vm.expectRevert("ForeignController/invalid-action");
         foreignController.reallocateMorpho(makeAddr("fake-vault"), new MarketAllocation[](0));
     }
@@ -235,7 +237,7 @@ contract MorphoReallocateMorphoSuccessTests is MorphoTestBase {
             assets       : 1_000_000e6
         });
 
-        vm.prank(relayer);
+        vm.prank(Base.SPARK_EXECUTOR);
         foreignController.reallocateMorpho(address(morphoVault), reallocations);
 
         // NOTE: No interest is accrued because deposit coverered all markets and is atomic
@@ -256,7 +258,7 @@ contract MorphoReallocateMorphoSuccessTests is MorphoTestBase {
             assets       : positionCBBTC + 400_000e6
         });
 
-        vm.prank(relayer);
+        vm.prank(Base.SPARK_EXECUTOR);
         foreignController.reallocateMorpho(address(morphoVault), reallocations);
 
         assertEq(positionAssets(usdcCBBTC), positionCBBTC + 400_000e6);


### PR DESCRIPTION
Based on Certora feedback, makes reallocations available only to a completely trusted role like the admin. 