### PR TITLE
ChainSecurity 5.2 and Certora L-03

### DIFF
--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -654,6 +654,8 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
             block.timestamp + 1 hours
         );
 
+        vm.warp(block.timestamp + 2 hours);
+
         // Change tick bounds
         vm.prank(GROVE_EXECUTOR);
         foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), tick.lower + 100);
@@ -686,6 +688,8 @@ contract ForeignControllerAddLiquidityFailureTests is UniswapV3TestBase {
             _minLiquidityPosition(desired.amount0, desired.amount1),
             block.timestamp + 1 hours
         );
+
+        vm.warp(block.timestamp + 2 hours);
 
         // Change tick bounds
         vm.prank(GROVE_EXECUTOR);


### PR DESCRIPTION
The previous fix PR doesn't check whether existing position ticks are within governance bounds. This PR updates to check ticks the user passes in on mint, and the tick position from the position on increaseLiquidity.