### PR TITLE
Certora C-01 Cleanup: Remove redundant min amount check on add liquidity

### DIFF
--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -837,7 +837,6 @@ contract ForeignController is AccessControl {
                 tokenIn      : tokenIn,
                 amountIn     : amountIn,
                 minAmountOut : minAmountOut,
-                maxSlippage  : maxSlippages[pool],
                 tickDelta    : swapMaxTickDelta,
                 poolParams   : uniswapV3PoolParams[pool]
             })

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -653,7 +653,6 @@ contract MainnetController is AccessControl {
                 tokenIn      : tokenIn,
                 amountIn     : amountIn,
                 minAmountOut : minAmountOut,
-                maxSlippage  : maxSlippages[pool],
                 tickDelta    : swapMaxTickDelta,
                 poolParams   : uniswapV3PoolParams[pool]
             })

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -51,7 +51,6 @@ library UniswapV3Lib {
         uint256             amountIn;
         uint256             minAmountOut;
         uint24              tickDelta; // The maximum that the tick can move by after completing the swap; cannot exceed MAX_TICK_DELTA
-        uint256             maxSlippage;
     }
 
     struct SwapCache {
@@ -86,7 +85,6 @@ library UniswapV3Lib {
 
     // Rate limit decreased by value of tokenIn (the amount actually spent)
     function swap(UniV3Context calldata context, SwapParams calldata params) external returns (uint256 amountOut) {
-        require(params.maxSlippage > 0,                                 "UniswapV3Lib/max-slippage-not-set");
         require(params.tickDelta <= params.poolParams.swapMaxTickDelta, "UniswapV3Lib/invalid-max-tick-delta");
         require(params.poolParams.twapSecondsAgo != 0,                  "UniswapV3Lib/zero-twap-seconds");
 

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -96,7 +96,7 @@ library UniswapV3Lib {
         uint256 startingBalance = IERC20(params.tokenIn).balanceOf(address(context.proxy));
         amountOut               = _callSwap(context, params, cache);
         uint256 endingBalance   = IERC20(params.tokenIn).balanceOf(address(context.proxy));
-        require(params.minAmountOut >= amountOut * params.maxSlippage / 1e18 , "UniswapV3Lib/min-amount-not-met");
+        require(params.minAmountOut > 0, "UniswapV3Lib/min-amount-not-met");
 
         // Clear approvals of dust
         ERC20Lib.approve(context.proxy, params.tokenIn, address(params.router), 0);

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -87,6 +87,7 @@ library UniswapV3Lib {
     function swap(UniV3Context calldata context, SwapParams calldata params) external returns (uint256 amountOut) {
         require(params.tickDelta <= params.poolParams.swapMaxTickDelta, "UniswapV3Lib/invalid-max-tick-delta");
         require(params.poolParams.twapSecondsAgo != 0,                  "UniswapV3Lib/zero-twap-seconds");
+        require(params.minAmountOut > 0,                                "UniswapV3Lib/min-amount-not-set");
 
         SwapCache memory cache = _populateSwapCache(context, params);
         ERC20Lib.approve(context.proxy, params.tokenIn, address(params.router), params.amountIn);
@@ -94,7 +95,6 @@ library UniswapV3Lib {
         uint256 startingBalance = IERC20(params.tokenIn).balanceOf(address(context.proxy));
         amountOut               = _callSwap(context, params, cache);
         uint256 endingBalance   = IERC20(params.tokenIn).balanceOf(address(context.proxy));
-        require(params.minAmountOut > 0, "UniswapV3Lib/min-amount-not-met");
 
         // Clear approvals of dust
         ERC20Lib.approve(context.proxy, params.tokenIn, address(params.router), 0);

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -129,9 +129,6 @@ library UniswapV3Lib {
 
         _validateAddLiquidityMinAmounts(context, params);
 
-        uint256 startingBalance0 = IERC20(token0).balanceOf(address(context.proxy));
-        uint256 startingBalance1 = IERC20(token1).balanceOf(address(context.proxy));
-
         if (params.tokenId == 0) {
             (tokenId, liquidity, amount0, amount1) = _mintLiquidity(context, params);
         } else {
@@ -139,14 +136,6 @@ library UniswapV3Lib {
         }
 
         require(liquidity != 0, "UniswapV3Lib/no-liquidity-increased");
-
-        {
-            uint256 balanceDiff0 = startingBalance0 - IERC20(token0).balanceOf(address(context.proxy));
-            uint256 balanceDiff1 = startingBalance1 - IERC20(token1).balanceOf(address(context.proxy));
-
-            require(params.min.amount0 >= balanceDiff0 * params.maxSlippage / 1e18, "UniswapV3Lib/min-amount-below-bound");
-            require(params.min.amount1 >= balanceDiff1 * params.maxSlippage / 1e18, "UniswapV3Lib/min-amount-below-bound");
-        }
 
         // Clear approvals of dust
         ERC20Lib.approve(context.proxy, token0, address(params.positionManager), 0);

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -289,25 +289,6 @@ contract ForeignControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
         );
     }
 
-    function test_swapUniswapV3_maxSlippageNotSet() public {
-        uint256 amountIn = 100_000e6;
-        _fundProxy(amountIn, 0);
-
-        vm.prank(GROVE_EXECUTOR);
-        foreignController.setMaxSlippage(_getPool(), 0);
-
-        vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("UniswapV3Lib/max-slippage-not-set");
-        foreignController.swapUniswapV3(
-            _getPool(),
-            address(token0),
-            amountIn,
-            0,
-            200
-        );
-        vm.stopPrank();
-    }
-
     function test_swapUniswapV3_invalidTokenIn() public {
         vm.startPrank(ALM_RELAYER);
         vm.expectRevert("UniswapV3Lib/invalid-token-pair");

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -260,7 +260,7 @@ contract MainnetControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
             _getPool(),
             address(dai),
             amountIn,
-            0,
+            1,
             200
         );
         vm.stopPrank();
@@ -324,7 +324,7 @@ contract MainnetControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
         _fundProxy(amountIn, 0);
 
         vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/min-amount-not-met");
+        vm.expectRevert("UniswapV3Lib/min-amount-not-set");
         mainnetController.swapUniswapV3(
             _getPool(),
             address(token0),

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -250,25 +250,6 @@ contract MainnetControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
         );
     }
 
-    function test_swapUniswapV3_maxSlippageNotSet() public {
-        uint256 amountIn = 100_000e6;
-        _fundProxy(amountIn, 0);
-
-        vm.prank(GROVE_PROXY);
-        mainnetController.setMaxSlippage(_getPool(), 0);
-
-        vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/max-slippage-not-set");
-        mainnetController.swapUniswapV3(
-            _getPool(),
-            address(token0),
-            amountIn,
-            0,
-            200
-        );
-        vm.stopPrank();
-    }
-
     function test_swapUniswapV3_invalidTokenIn() public {
         uint256 amountIn = 100_000e6;
         deal(address(dai), address(almProxy), amountIn);


### PR DESCRIPTION
Removes add liquidity spot price check as it's redundant and may trigger unintended reverts.