### PR TITLE
[GROVE-250] chore: shorten error strings

### DIFF
--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -621,7 +621,7 @@ contract ForeignController is AccessControl {
         );
 
         bytes32 recipient = centrifugeRecipients[destinationCentrifugeId];
-        require(recipient != 0, "FC/centrifuge-id-not-configured");
+        require(recipient != 0, "FC/id-not-configured");
 
         ICentrifugeV3VaultLike centrifugeVault = ICentrifugeV3VaultLike(token);
 

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -167,7 +167,7 @@ contract ForeignController is AccessControl {
     modifier rateLimitExists(bytes32 key) {
         require(
             rateLimits.getRateLimitData(key).maxAmount > 0,
-            "ForeignController/invalid-action"
+            "FC/invalid-action"
         );
         _;
     }
@@ -196,7 +196,7 @@ contract ForeignController is AccessControl {
         external
         onlyRole(DEFAULT_ADMIN_ROLE)
     {
-        require(maxSlippage <= 1e18, "ForeignController/max-slippage-out-of-bounds");
+        require(maxSlippage <= 1e18, "FC/max-slippage-oob");
         maxSlippages[pool] = maxSlippage;
         emit MaxSlippageSet(pool, maxSlippage);
     }
@@ -215,7 +215,7 @@ contract ForeignController is AccessControl {
         require(
             maxTickDelta > 0 &&
             maxTickDelta <= UniswapV3Lib.MAX_TICK_DELTA,
-            "ForeignController/max-tick-delta-out-of-bounds"
+            "FC/max-tick-delta-oob"
         );
 
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
@@ -225,7 +225,7 @@ contract ForeignController is AccessControl {
 
     function setUniswapV3AddLiquidityLowerTickBound(address pool, int24 lowerTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "ForeignController/lower-tick-out-of-bounds");
+        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "FC/lower-tick-oob");
 
         params.addLiquidityTickBounds.lower = lowerTickBound;
         emit UniswapV3PoolLowerTickUpdated(pool, lowerTickBound);
@@ -233,7 +233,7 @@ contract ForeignController is AccessControl {
 
     function setUniswapV3AddLiquidityUpperTickBound(address pool, int24 upperTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "ForeignController/upper-tick-out-of-bounds");
+        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "FC/upper-tick-oob");
 
         params.addLiquidityTickBounds.upper = upperTickBound;
         emit UniswapV3PoolUpperTickUpdated(pool, upperTickBound);
@@ -243,7 +243,7 @@ contract ForeignController is AccessControl {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
         // Required due to casting in UniswapV3OracleLibrary.consult
         // Limits twapSecondsAgo to approximately 68 years
-        require(twapSecondsAgo < uint32(type(int32).max), "ForeignController/twap-seconds-ago-out-of-bounds");
+        require(twapSecondsAgo < uint32(type(int32).max), "FC/twap-seconds-ago-oob");
         params.twapSecondsAgo = twapSecondsAgo;
         emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }
@@ -259,7 +259,7 @@ contract ForeignController is AccessControl {
     function setMaxExchangeRate(address token, uint256 shares, uint256 maxExpectedAssets) external {
         _checkRole(DEFAULT_ADMIN_ROLE);
 
-        require(token != address(0), "ForeignController/token-zero-address");
+        require(token != address(0), "FC/token-zero-address");
 
         emit MaxExchangeRateSet(
             token,
@@ -436,7 +436,7 @@ contract ForeignController is AccessControl {
 
         require(
             _getExchangeRate(shares, amount) <= maxExchangeRates[token],
-            "ForeignController/exchange-rate-too-high"
+            "FC/exchange-rate-too-high"
         );
     }
 
@@ -621,7 +621,7 @@ contract ForeignController is AccessControl {
         );
 
         bytes32 recipient = centrifugeRecipients[destinationCentrifugeId];
-        require(recipient != 0, "ForeignController/centrifuge-id-not-configured");
+        require(recipient != 0, "FC/centrifuge-id-not-configured");
 
         ICentrifugeV3VaultLike centrifugeVault = ICentrifugeV3VaultLike(token);
 
@@ -654,7 +654,7 @@ contract ForeignController is AccessControl {
         onlyRole(RELAYER)
         rateLimitedAsset(LIMIT_AAVE_DEPOSIT, aToken, amount)
     {
-        require(maxSlippages[aToken] != 0, "ForeignController/max-slippage-not-set");
+        require(maxSlippages[aToken] != 0, "FC/max-slippage-not-set");
 
         IERC20    underlying = IERC20(IATokenWithPool(aToken).UNDERLYING_ASSET_ADDRESS());
         IAavePool pool       = IAavePool(IATokenWithPool(aToken).POOL());
@@ -674,7 +674,7 @@ contract ForeignController is AccessControl {
 
         require(
             newATokens >= amount * maxSlippages[aToken] / 1e18,
-            "ForeignController/slippage-too-high"
+            "FC/slippage-too-high"
         );
     }
 
@@ -780,7 +780,7 @@ contract ForeignController is AccessControl {
 
     function toggleOperatorMerkl(address operator) external {
         _checkRole(RELAYER);
-        require(address(merklDistributor) != address(0), "ForeignController/merkl-distributor-not-set");
+        require(address(merklDistributor) != address(0), "FC/merkl-distributor-not-set");
 
         MerklLib.toggleOperator(MerklLib.MerklToggleOperatorParams({
             proxy        : proxy,
@@ -928,7 +928,7 @@ contract ForeignController is AccessControl {
         if (assets == 0) return 0;
 
         // Zero shares with non-zero assets is invalid (infinite exchange rate).
-        if (shares == 0) revert("ForeignController/zero-shares");
+        if (shares == 0) revert("FC/zero-shares");
 
         return (EXCHANGE_RATE_PRECISION * assets) / shares;
     }

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -205,7 +205,7 @@ contract MainnetController is AccessControl {
 
     function setMaxSlippage(address pool, uint256 maxSlippage) external {
         _checkRole(DEFAULT_ADMIN_ROLE);
-        require(maxSlippage <= 1e18, "MainnetController/max-slippage-out-of-bounds");
+        require(maxSlippage <= 1e18, "MC/max-slippage-oob");
         maxSlippages[pool] = maxSlippage;
         emit MaxSlippageSet(pool, maxSlippage);
     }
@@ -216,7 +216,7 @@ contract MainnetController is AccessControl {
         require(
             maxTickDelta > 0 &&
             maxTickDelta <= UniswapV3Lib.MAX_TICK_DELTA,
-            "MainnetController/max-tick-delta-out-of-bounds"
+            "MC/max-tick-delta-oob"
         );
 
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
@@ -226,7 +226,7 @@ contract MainnetController is AccessControl {
 
     function setUniswapV3AddLiquidityLowerTickBound(address pool, int24 lowerTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "MainnetController/lower-tick-out-of-bounds");
+        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "MC/lower-tick-oob");
 
         params.addLiquidityTickBounds.lower = lowerTickBound;
         emit UniswapV3PoolLowerTickUpdated(pool, lowerTickBound);
@@ -234,7 +234,7 @@ contract MainnetController is AccessControl {
 
     function setUniswapV3AddLiquidityUpperTickBound(address pool, int24 upperTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "MainnetController/upper-tick-out-of-bounds");
+        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "MC/upper-tick-oob");
 
         params.addLiquidityTickBounds.upper = upperTickBound;
         emit UniswapV3PoolUpperTickUpdated(pool, upperTickBound);
@@ -244,7 +244,7 @@ contract MainnetController is AccessControl {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
         // Required due to casting in UniswapV3OracleLibrary.consult
         // Limits twapSecondsAgo to approximately 68 years
-        require(twapSecondsAgo < uint32(type(int32).max), "MainnetController/twap-seconds-ago-out-of-bounds");
+        require(twapSecondsAgo < uint32(type(int32).max), "MC/twap-seconds-ago-oob");
         params.twapSecondsAgo = twapSecondsAgo;
         emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }
@@ -258,7 +258,7 @@ contract MainnetController is AccessControl {
     function setMaxExchangeRate(address token, uint256 shares, uint256 maxExpectedAssets) external {
         _checkRole(DEFAULT_ADMIN_ROLE);
 
-        require(token != address(0), "MainnetController/token-zero-address");
+        require(token != address(0), "MC/token-zero-address");
 
         emit MaxExchangeRateSet(
             token,
@@ -350,7 +350,7 @@ contract MainnetController is AccessControl {
 
         require(
             _getExchangeRate(shares, amount) <= maxExchangeRates[token],
-            "MainnetController/exchange-rate-too-high"
+            "MC/exchange-rate-too-high"
         );
     }
 
@@ -506,7 +506,7 @@ contract MainnetController is AccessControl {
         _checkRole(RELAYER);
         _rateLimitedAsset(LIMIT_AAVE_DEPOSIT, aToken, amount);
 
-        require(maxSlippages[aToken] != 0, "MainnetController/max-slippage-not-set");
+        require(maxSlippages[aToken] != 0, "MC/max-slippage-not-set");
 
         IERC20    underlying = IERC20(IATokenWithPool(aToken).UNDERLYING_ASSET_ADDRESS());
         IAavePool pool       = IAavePool(IATokenWithPool(aToken).POOL());
@@ -526,7 +526,7 @@ contract MainnetController is AccessControl {
 
         require(
             newATokens >= amount * maxSlippages[aToken] / 1e18,
-            "MainnetController/slippage-too-high"
+            "MC/slippage-too-high"
         );
     }
 
@@ -994,7 +994,7 @@ contract MainnetController is AccessControl {
     function _rateLimitExists(bytes32 key) internal view {
         require(
             rateLimits.getRateLimitData(key).maxAmount > 0,
-            "MainnetController/invalid-action"
+            "MC/invalid-action"
         );
     }
 
@@ -1035,7 +1035,7 @@ contract MainnetController is AccessControl {
         if (assets == 0) return 0;
 
         // Zero shares with non-zero assets is invalid (infinite exchange rate).
-        if (shares == 0) revert("MainnetController/zero-shares");
+        if (shares == 0) revert("MC/zero-shares");
 
         return (EXCHANGE_RATE_PRECISION * assets) / shares;
     }

--- a/src/libraries/CentrifugeLib.sol
+++ b/src/libraries/CentrifugeLib.sol
@@ -89,7 +89,7 @@ library CentrifugeLib {
             params.amount
         );
 
-        require(params.recipient != 0, "MainnetController/centrifuge-id-not-configured");
+        require(params.recipient != 0, "CentrifugeLib/centrifuge-id-not-configured");
 
         ICentrifugeV3VaultLike centrifugeVault = ICentrifugeV3VaultLike(params.token);
 
@@ -124,7 +124,7 @@ library CentrifugeLib {
     function _rateLimitExists(IRateLimits rateLimits, bytes32 key) internal view {
         require(
             rateLimits.getRateLimitData(key).maxAmount > 0,
-            "MainnetController/invalid-action"
+            "CentrifugeLib/invalid-action"
         );
     }
 }

--- a/src/libraries/CentrifugeLib.sol
+++ b/src/libraries/CentrifugeLib.sol
@@ -89,7 +89,7 @@ library CentrifugeLib {
             params.amount
         );
 
-        require(params.recipient != 0, "CentrifugeLib/centrifuge-id-not-configured");
+        require(params.recipient != 0, "CentrifugeLib/id-not-configured");
 
         ICentrifugeV3VaultLike centrifugeVault = ICentrifugeV3VaultLike(params.token);
 

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -464,7 +464,7 @@ library UniswapV3Lib {
         ) = _fetchPositionData(params.tokenId, params.positionManager);
 
         require(positionToken0 == token0 && positionToken1 == token1 && positionFee == fee, "UniswapV3Lib/invalid-pool");
-        require(params.liquidity > 0 && params.liquidity <= positionLiquidity,              "UniswapV3Lib/liquidity-out-of-bounds");
+        require(params.liquidity > 0 && params.liquidity <= positionLiquidity,              "UniswapV3Lib/liquidity-oob");
     }
 
     function _decreaseLiquidityCall(

--- a/test/grove-avalanche-fork/Centrifuge.t.sol
+++ b/test/grove-avalanche-fork/Centrifuge.t.sol
@@ -1012,7 +1012,7 @@ contract ForeignControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
         deal(ALM_RELAYER, 1 ether);  // Gas cost for Centrifuge
 
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("FC/centrifuge-id-not-configured");
+        vm.expectRevert("FC/id-not-configured");
         foreignController.transferSharesCentrifuge{value: 0.5 ether}(
             CENTRIFUGE_VAULT,
             10_000_000e6,

--- a/test/grove-avalanche-fork/Centrifuge.t.sol
+++ b/test/grove-avalanche-fork/Centrifuge.t.sol
@@ -172,7 +172,7 @@ contract ForeignControllerClaimDepositERC7540FailureTests is CentrifugeTestBase 
 
     function test_claimDepositERC7540_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimDepositERC7540(makeAddr("fake-vault"));
     }
 
@@ -343,7 +343,7 @@ contract ForeignControllerCancelCentrifugeDepositFailureTests is CentrifugeTestB
 
     function test_cancelCentrifugeDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.cancelCentrifugeDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -399,7 +399,7 @@ contract ForeignControllerClaimCentrifugeCancelDepositFailureTests is Centrifuge
 
     function test_claimCentrifugeCancelDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimCentrifugeCancelDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -592,7 +592,7 @@ contract ForeignControllerClaimRedeemERC7540FailureTests is CentrifugeTestBase {
 
     function test_claimRedeemERC7540_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimRedeemERC7540(makeAddr("fake-vault"));
     }
 
@@ -795,7 +795,7 @@ contract ForeignControllerCancelCentrifugeRedeemRequestFailureTests is Centrifug
 
     function test_cancelCentrifugeRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.cancelCentrifugeRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -855,7 +855,7 @@ contract ForeignControllerClaimCentrifugeCancelRedeemRequestFailureTests is Cent
 
     function test_claimCentrifugeCancelRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimCentrifugeCancelRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -1012,7 +1012,7 @@ contract ForeignControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
         deal(ALM_RELAYER, 1 ether);  // Gas cost for Centrifuge
 
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/centrifuge-id-not-configured");
+        vm.expectRevert("FC/centrifuge-id-not-configured");
         foreignController.transferSharesCentrifuge{value: 0.5 ether}(
             CENTRIFUGE_VAULT,
             10_000_000e6,

--- a/test/grove-base-fork/Merkl.sol
+++ b/test/grove-base-fork/Merkl.sol
@@ -29,7 +29,7 @@ contract MerklBaseTest is ForkTestBase {
 contract ForeignControllerToggleOperatorMerklFailureTests is MerklBaseTest {
 
     function test_toggleOperatorMerkl_merklDistributorNotSet() external {
-        vm.expectRevert("ForeignController/merkl-distributor-not-set");
+        vm.expectRevert("FC/merkl-distributor-not-set");
 
         vm.prank(relayer);
         foreignController.toggleOperatorMerkl(operator1);

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -219,19 +219,19 @@ contract ForeignControllerConfigFailureTests is UniswapV3TestBase {
 
     function test_setUniswapV3PoolMaxTickDelta_isZero() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_isTooLarge() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), UniswapV3Lib.MAX_TICK_DELTA + 1);
     }
 
     function test_setUniswapV3AddLiquidityLowerTickBound_isTooSmall() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), MIN_UNISWAP_TICK - 1);
     }
 
@@ -240,13 +240,13 @@ contract ForeignControllerConfigFailureTests is UniswapV3TestBase {
         int24 currentUpper = tickBounds.upper;
 
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), currentUpper);
     }
 
     function test_setUniswapV3AddLiquidityUpperTickBound_isTooLarge() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), MAX_UNISWAP_TICK + 1);
     }
 }
@@ -264,13 +264,13 @@ contract ForeignControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
 
     function test_setUniswapV3PoolMaxTickDelta_zeroTickDelta() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_outOfBounds() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), UniswapV3Lib.MAX_TICK_DELTA + 1);
     }
 
@@ -1244,7 +1244,7 @@ contract ForeignControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_zeroLiquidity() public {
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         foreignController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,
@@ -1257,7 +1257,7 @@ contract ForeignControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_liquidityTooHigh() public {
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         foreignController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,

--- a/test/grove-mainnet-fork/4626Calls.t.sol
+++ b/test/grove-mainnet-fork/4626Calls.t.sol
@@ -91,7 +91,7 @@ contract MainnetControllerDepositERC4626FailureTests is SUSDSTestBase {
         vm.stopPrank();
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/exchange-rate-too-high");
+        vm.expectRevert("MC/exchange-rate-too-high");
         mainnetController.depositERC4626(address(susds), 5_000_000e18);
 
         vm.startPrank(Ethereum.GROVE_PROXY);
@@ -110,7 +110,7 @@ contract MainnetControllerDepositERC4626FailureTests is SUSDSTestBase {
         mainnetController.setMaxExchangeRate(address(susds), 0, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/exchange-rate-too-high");
+        vm.expectRevert("MC/exchange-rate-too-high");
         mainnetController.depositERC4626(address(susds), 5_000_000e18);
     }
 

--- a/test/grove-mainnet-fork/Aave.t.sol
+++ b/test/grove-mainnet-fork/Aave.t.sol
@@ -94,7 +94,7 @@ contract AaveV3MainMarketDepositFailureTests is AaveV3MainMarketBaseTest {
         mainnetController.setMaxSlippage(ATOKEN_USDS, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/max-slippage-not-set");
+        vm.expectRevert("MC/max-slippage-not-set");
         mainnetController.depositAave(ATOKEN_USDS, 1_000_000e18);
     }
 

--- a/test/grove-mainnet-fork/Centrifuge.t.sol
+++ b/test/grove-mainnet-fork/Centrifuge.t.sol
@@ -182,7 +182,7 @@ contract MainnetControllerClaimDepositERC7540FailureTests is CentrifugeTestBase 
 
     function test_claimDepositERC7540_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("MC/invalid-action");
         mainnetController.claimDepositERC7540(makeAddr("fake-vault"));
     }
 
@@ -331,7 +331,7 @@ contract MainnetControllerCancelCentrifugeDepositFailureTests is CentrifugeTestB
 
     function test_cancelCentrifugeDepositRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.cancelCentrifugeDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -387,7 +387,7 @@ contract MainnetControllerClaimCentrifugeCancelDepositFailureTests is Centrifuge
 
     function test_claimCentrifugeCancelDepositRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.claimCentrifugeCancelDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -575,7 +575,7 @@ contract MainnetControllerClaimRedeemERC7540FailureTests is CentrifugeTestBase {
 
     function test_claimRedeemERC7540_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("MC/invalid-action");
         mainnetController.claimRedeemERC7540(makeAddr("fake-vault"));
     }
 
@@ -740,7 +740,7 @@ contract MainnetControllerCancelCentrifugeRedeemRequestFailureTests is Centrifug
 
     function test_cancelCentrifugeRedeemRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.cancelCentrifugeRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -800,7 +800,7 @@ contract MainnetControllerClaimCentrifugeCancelRedeemRequestFailureTests is Cent
 
     function test_claimCentrifugeCancelRedeemRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.claimCentrifugeCancelRedeemRequest(makeAddr("fake-vault"));
     }
 

--- a/test/grove-mainnet-fork/CentrifugeV3.t.sol
+++ b/test/grove-mainnet-fork/CentrifugeV3.t.sol
@@ -117,7 +117,7 @@ contract MainnetControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
         deal(relayer, 1 ether);  // Gas cost for Centrifuge
 
         vm.startPrank(relayer);
-        vm.expectRevert("MainnetController/centrifuge-id-not-configured");
+        vm.expectRevert("CentrifugeLib/centrifuge-id-not-configured");
         mainnetController.transferSharesCentrifuge{value: 0.1 ether}(
             CENTRIFUGE_VAULT,
             10_000_000e6,

--- a/test/grove-mainnet-fork/CentrifugeV3.t.sol
+++ b/test/grove-mainnet-fork/CentrifugeV3.t.sol
@@ -117,7 +117,7 @@ contract MainnetControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
         deal(relayer, 1 ether);  // Gas cost for Centrifuge
 
         vm.startPrank(relayer);
-        vm.expectRevert("CentrifugeLib/centrifuge-id-not-configured");
+        vm.expectRevert("CentrifugeLib/id-not-configured");
         mainnetController.transferSharesCentrifuge{value: 0.1 ether}(
             CENTRIFUGE_VAULT,
             10_000_000e6,

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -191,19 +191,19 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
 
     function test_setUniswapV3PoolMaxTickDelta_isZero() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(_getPool(), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_isTooLarge() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(_getPool(), UniswapV3Lib.MAX_TICK_DELTA + 1);
     }
 
     function test_setUniswapV3AddLiquidityLowerTickBound_isTooSmall() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), MIN_UNISWAP_TICK - 1);
     }
 
@@ -213,7 +213,7 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
         int24 currentUpper = tickBounds.upper;
 
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), currentUpper);
     }
 
@@ -222,13 +222,13 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
         int24 currentLower = tickBounds.lower;
 
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), currentLower);
     }
 
     function test_setUniswapV3AddLiquidityUpperTickBound_isTooLarge() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), MAX_UNISWAP_TICK + 1);
     }
 }
@@ -1617,7 +1617,7 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_zeroLiquidity() public {
         vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         mainnetController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,
@@ -1630,7 +1630,7 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_liquidityTooHigh() public {
         vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         mainnetController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,

--- a/test/spark-base-fork/Aave.t.sol
+++ b/test/spark-base-fork/Aave.t.sol
@@ -74,7 +74,7 @@ contract AaveV3BaseMarketDepositFailureTests is AaveV3BaseMarketTestBase {
         foreignController.setMaxSlippage(ATOKEN_USDC, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("ForeignController/max-slippage-not-set");
+        vm.expectRevert("FC/max-slippage-not-set");
         foreignController.depositAave(ATOKEN_USDC, 1_000_000e6);
     }
 

--- a/test/spark-base-fork/Morpho.t.sol
+++ b/test/spark-base-fork/Morpho.t.sol
@@ -160,7 +160,7 @@ contract MorphoDepositFailureTests is MorphoBaseTest {
         vm.stopPrank();
 
         vm.prank(relayer);
-        vm.expectRevert("ForeignController/exchange-rate-too-high");
+        vm.expectRevert("FC/exchange-rate-too-high");
         foreignController.depositERC4626(MORPHO_VAULT_USDS, 25_000_000e18);
 
         vm.startPrank(Base.SPARK_EXECUTOR);
@@ -178,7 +178,7 @@ contract MorphoDepositFailureTests is MorphoBaseTest {
         foreignController.setMaxExchangeRate(MORPHO_VAULT_USDS, 0, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("ForeignController/exchange-rate-too-high");
+        vm.expectRevert("FC/exchange-rate-too-high");
         foreignController.depositERC4626(MORPHO_VAULT_USDS, 1e18);
     }
 

--- a/test/spark-mainnet-fork/ERC4626DonationAttack.t.sol
+++ b/test/spark-mainnet-fork/ERC4626DonationAttack.t.sol
@@ -92,7 +92,7 @@ contract ERC4626DonationAttack is ERC4626DonationAttackTestBase {
         _doAttack();
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/exchange-rate-too-high");
+        vm.expectRevert("MC/exchange-rate-too-high");
         mainnetController.depositERC4626(address(morphoVault), 2_000_000e18);
     }
 

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -183,7 +183,7 @@ contract MainnetControllerSetMaxSlippageTests is MainnetControllerAdminTestBase 
 
     function test_setMaxSlippage_outOfBounds() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/max-slippage-out-of-bounds");
+        vm.expectRevert("MC/max-slippage-oob");
         mainnetController.setMaxSlippage(makeAddr("pool"), 1e18 + 1);
     }
 }
@@ -209,13 +209,13 @@ contract MainnetControllerSetUniswapV3PoolMaxTickDeltaTests is MainnetController
 
     function test_setUniswapV3PoolMaxTickDelta_zeroMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_exceedsMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 887273); // MAX_TICK_DELTA + 1
     }
 
@@ -265,7 +265,7 @@ contract MainnetControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Mainnet
 
     function test_setUniswapV3AddLiquidityLowerTickBound_belowMinTick() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -887273); // MIN_TICK - 1
     }
 
@@ -278,11 +278,11 @@ contract MainnetControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Mainnet
 
         // Try to set lower tick at or above the upper tick
         vm.prank(admin);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, 1001);
     }
 
@@ -338,7 +338,7 @@ contract MainnetControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Mainnet
 
     function test_setUniswapV3AddLiquidityUpperTickBound_aboveMaxTick() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 887273); // MAX_TICK + 1
     }
 
@@ -353,11 +353,11 @@ contract MainnetControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Mainnet
 
         // Try to set upper tick at or below the lower tick
         vm.prank(admin);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 999);
     }
 
@@ -411,10 +411,10 @@ contract MainnetControllerSetUniswapV3TwapSecondsAgoTests is MainnetControllerAd
     function test_setUniswapV3TwapSecondsAgo_outOfBounds() public {
         vm.startPrank(admin);
 
-        vm.expectRevert("MainnetController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("MC/twap-seconds-ago-oob");
         mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), uint32(type(int32).max));
 
-        vm.expectRevert("MainnetController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("MC/twap-seconds-ago-oob");
         mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), type(uint32).max);
 
         vm.stopPrank();
@@ -612,7 +612,7 @@ contract ForeignControllerSetMaxSlippageTests is ForeignControllerAdminTestBase 
 
     function test_setMaxSlippage_outOfBounds() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/max-slippage-out-of-bounds");
+        vm.expectRevert("FC/max-slippage-oob");
         foreignController.setMaxSlippage(makeAddr("pool"), 1e18 + 1);
     }
 }
@@ -638,13 +638,13 @@ contract ForeignControllerSetUniswapV3PoolMaxTickDeltaTests is ForeignController
 
     function test_setUniswapV3PoolMaxTickDelta_zeroMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_exceedsMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 887273); // MAX_TICK_DELTA + 1
     }
 
@@ -694,7 +694,7 @@ contract ForeignControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Foreign
 
     function test_setUniswapV3AddLiquidityLowerTickBound_belowMinTick() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -887273); // MIN_TICK - 1
     }
 
@@ -707,11 +707,11 @@ contract ForeignControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Foreign
 
         // Try to set lower tick at or above the upper tick
         vm.prank(admin);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, 1001);
     }
 
@@ -767,7 +767,7 @@ contract ForeignControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Foreign
 
     function test_setUniswapV3AddLiquidityUpperTickBound_aboveMaxTick() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 887273); // MAX_TICK + 1
     }
 
@@ -782,11 +782,11 @@ contract ForeignControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Foreign
 
         // Try to set upper tick at or below the lower tick
         vm.prank(admin);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 999);
     }
 
@@ -864,10 +864,10 @@ contract ForeignControllerSetUniswapV3TwapSecondsAgoTests is ForeignControllerAd
     function test_setUniswapV3TwapSecondsAgo_outOfBounds() public {
         vm.startPrank(admin);
 
-        vm.expectRevert("ForeignController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("FC/twap-seconds-ago-oob");
         foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), uint32(type(int32).max));
 
-        vm.expectRevert("ForeignController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("FC/twap-seconds-ago-oob");
         foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), type(uint32).max);
 
         vm.stopPrank();


### PR DESCRIPTION
**Runtime margin changes**

_ForeignController_: 1,639 B -> 1,946 B
_MainnetController_: 1,455 B -> 1,720 B

<img width="210" height="140" alt="image" src="https://github.com/user-attachments/assets/9ec2c192-8fc4-4bd1-b6dd-f08486139e9b" />
