### PR TITLE
refactor: extract RateLimitKeysLib

### DIFF
--- a/script/staging/FullStagingDeploy.s.sol
+++ b/script/staging/FullStagingDeploy.s.sol
@@ -42,6 +42,7 @@ import { MainnetControllerInit } from "../../deploy/MainnetControllerInit.sol";
 import { IRateLimits } from "../../src/interfaces/IRateLimits.sol";
 
 import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
 import { MockJug }          from "./mocks/MockJug.sol";
 import { MockUsdsJoin }     from "./mocks/MockUsdsJoin.sol";
@@ -414,23 +415,23 @@ contract FullStagingDeploy is Script {
 
         vm.startBroadcast();
 
-        bytes32 susdeDepositKey = RateLimitHelpers.makeAssetKey(controller.LIMIT_4626_DEPOSIT(), address(controller.susde()));
+        bytes32 susdeDepositKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_DEPOSIT, address(controller.susde()));
 
-        bytes32 domainKeyArbitrum = RateLimitHelpers.makeDomainKey(controller.LIMIT_USDC_TO_DOMAIN(), CCTPForwarder.DOMAIN_ID_CIRCLE_ARBITRUM_ONE);
-        bytes32 domainKeyBase     = RateLimitHelpers.makeDomainKey(controller.LIMIT_USDC_TO_DOMAIN(), CCTPForwarder.DOMAIN_ID_CIRCLE_BASE);
+        bytes32 domainKeyArbitrum = RateLimitHelpers.makeDomainKey(RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN, CCTPForwarder.DOMAIN_ID_CIRCLE_ARBITRUM_ONE);
+        bytes32 domainKeyBase     = RateLimitHelpers.makeDomainKey(RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE);
 
         // USDS mint/burn and cross-chain transfer rate limits
-        rateLimits.setRateLimitData(domainKeyBase,                   maxAmount6,  slope6);
-        rateLimits.setRateLimitData(domainKeyArbitrum,               maxAmount6,  slope6);
-        rateLimits.setRateLimitData(controller.LIMIT_USDS_MINT(),    maxAmount18, slope18);
-        rateLimits.setRateLimitData(controller.LIMIT_USDS_TO_USDC(), maxAmount6,  slope6);
+        rateLimits.setRateLimitData(domainKeyBase,                        maxAmount6,  slope6);
+        rateLimits.setRateLimitData(domainKeyArbitrum,                    maxAmount6,  slope6);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_MINT,    maxAmount18, slope18);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_TO_USDC, maxAmount6,  slope6);
 
-        rateLimits.setUnlimitedRateLimitData(controller.LIMIT_USDC_TO_CCTP());
+        rateLimits.setUnlimitedRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP);
 
         // Ethena-specific rate limits
-        rateLimits.setRateLimitData(controller.LIMIT_SUSDE_COOLDOWN(), maxAmount18, slope18);
-        rateLimits.setRateLimitData(controller.LIMIT_USDE_BURN(),      maxAmount18, slope18);
-        rateLimits.setRateLimitData(controller.LIMIT_USDE_MINT(),      maxAmount6,  slope6);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN, maxAmount18, slope18);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDE_BURN,      maxAmount18, slope18);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDE_MINT,      maxAmount6,  slope6);
         rateLimits.setRateLimitData(susdeDepositKey,                   maxAmount18, slope18);
 
         vm.stopBroadcast();
@@ -444,11 +445,11 @@ contract FullStagingDeploy is Script {
 
         IRateLimits rateLimits = IRateLimits(controllerInst.rateLimits);
 
-        bytes32 psmDepositKey  = foreignController.LIMIT_PSM_DEPOSIT();
-        bytes32 psmWithdrawKey = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 psmDepositKey  = RateLimitKeysLib.LIMIT_PSM_DEPOSIT;
+        bytes32 psmWithdrawKey = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
 
         bytes32 domainKeyEthereum = RateLimitHelpers.makeDomainKey(
-            foreignController.LIMIT_USDC_TO_DOMAIN(),
+            RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
             CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM
         );
 
@@ -467,7 +468,7 @@ contract FullStagingDeploy is Script {
 
         // CCTP rate limits
         rateLimits.setRateLimitData(domainKeyEthereum, maxAmount6, slope6);
-        rateLimits.setUnlimitedRateLimitData(foreignController.LIMIT_USDC_TO_CCTP());
+        rateLimits.setUnlimitedRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP);
 
         vm.stopBroadcast();
     }
@@ -502,8 +503,8 @@ contract FullStagingDeploy is Script {
         vm.startBroadcast();
 
         // NOTE: MainnetController and ForeignController both have the same LIMIT constants for this
-        bytes32 depositKey  = MainnetController(controllerInst.controller).LIMIT_AAVE_DEPOSIT();
-        bytes32 withdrawKey = MainnetController(controllerInst.controller).LIMIT_AAVE_WITHDRAW();
+        bytes32 depositKey  = RateLimitKeysLib.LIMIT_AAVE_DEPOSIT;
+        bytes32 withdrawKey = RateLimitKeysLib.LIMIT_AAVE_WITHDRAW;
 
         IRateLimits rateLimits = IRateLimits(controllerInst.rateLimits);
 
@@ -526,8 +527,8 @@ contract FullStagingDeploy is Script {
         vm.startBroadcast();
 
         // NOTE: MainnetController and ForeignController both have the same LIMIT constants for this
-        bytes32 depositKey  = MainnetController(controllerInst.controller).LIMIT_4626_DEPOSIT();
-        bytes32 withdrawKey = MainnetController(controllerInst.controller).LIMIT_4626_WITHDRAW();
+        bytes32 depositKey  = RateLimitKeysLib.LIMIT_4626_DEPOSIT;
+        bytes32 withdrawKey = RateLimitKeysLib.LIMIT_4626_WITHDRAW;
 
         IRateLimits rateLimits = IRateLimits(controllerInst.rateLimits);
 

--- a/script/staging/test/FullStagingDeployment.t.sol
+++ b/script/staging/test/FullStagingDeployment.t.sol
@@ -37,7 +37,8 @@ import { ForeignController } from "../../../src/ForeignController.sol";
 import { MainnetController } from "../../../src/MainnetController.sol";
 import { RateLimits }        from "../../../src/RateLimits.sol";
 
-import { RateLimitHelpers }  from "../../../src/RateLimitHelpers.sol";
+import { RateLimitHelpers } from "../../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../../src/libraries/RateLimitKeysLib.sol";
 
 interface IVatLike {
     function can(address, address) external view returns (uint256);
@@ -353,7 +354,7 @@ contract FullMainnetStagingDeploymentTests is StagingDeploymentTestBase {
         mainnetController.unstakeSUSDe();
 
         // Handle situation where usde balance of ALM Proxy is higher than max rate limit
-        uint256 maxBurnAmount = rateLimits.getCurrentRateLimit(mainnetController.LIMIT_USDE_BURN());
+        uint256 maxBurnAmount = rateLimits.getCurrentRateLimit(RateLimitKeysLib.LIMIT_USDE_BURN);
         uint256 burnAmount    = usdeAmount > maxBurnAmount ? maxBurnAmount : usdeAmount;
         mainnetController.prepareUSDeBurn(burnAmount);
 

--- a/script/staging/test/MainnetStagingDeployment.t.sol
+++ b/script/staging/test/MainnetStagingDeployment.t.sol
@@ -37,7 +37,8 @@ import { ForeignController } from "../../../src/ForeignController.sol";
 import { MainnetController } from "../../../src/MainnetController.sol";
 import { RateLimits }        from "../../../src/RateLimits.sol";
 
-import { RateLimitHelpers }  from "../../../src/RateLimitHelpers.sol";
+import { RateLimitHelpers } from "../../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../../src/libraries/RateLimitKeysLib.sol";
 
 interface IVatLike {
     function can(address, address) external view returns (uint256);
@@ -235,7 +236,7 @@ contract MainnetStagingDeploymentTests is MainnetStagingDeploymentTestBase {
         mainnetController.unstakeSUSDe();
 
         // Handle situation where usde balance of ALM Proxy is higher than max rate limit
-        uint256 maxBurnAmount = rateLimits.getCurrentRateLimit(mainnetController.LIMIT_USDE_BURN());
+        uint256 maxBurnAmount = rateLimits.getCurrentRateLimit(RateLimitKeysLib.LIMIT_USDE_BURN);
         uint256 burnAmount    = usdeAmount > maxBurnAmount ? maxBurnAmount : usdeAmount;
         mainnetController.prepareUSDeBurn(burnAmount);
 

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -18,13 +18,14 @@ import { ICCTPLike }     from "./interfaces/CCTPInterfaces.sol";
 import { IRateLimits }   from "./interfaces/IRateLimits.sol";
 import { IPendleMarket } from "./interfaces/PendleInterfaces.sol";
 
-import { CentrifugeLib } from "./libraries/CentrifugeLib.sol";
-import { CurveLib }      from "./libraries/CurveLib.sol";
-import { MerklLib }      from "./libraries/MerklLib.sol";
-import { PendleLib }     from "./libraries/PendleLib.sol";
-import { CCTPLib }       from "./libraries/CCTPLib.sol";
-import { ERC20Lib }      from "./libraries/common/ERC20Lib.sol";
-import { UniswapV3Lib }  from "./libraries/UniswapV3Lib.sol";
+import { CentrifugeLib }    from "./libraries/CentrifugeLib.sol";
+import { CurveLib }         from "./libraries/CurveLib.sol";
+import { MerklLib }         from "./libraries/MerklLib.sol";
+import { PendleLib }        from "./libraries/PendleLib.sol";
+import { RateLimitKeysLib } from "./libraries/RateLimitKeysLib.sol";
+import { CCTPLib }          from "./libraries/CCTPLib.sol";
+import { ERC20Lib }         from "./libraries/common/ERC20Lib.sol";
+import { UniswapV3Lib }     from "./libraries/UniswapV3Lib.sol";
 
 import { ISwapRouter, INonfungiblePositionManager }                    from "./interfaces/UniswapV3Interfaces.sol";
 import { ICentrifugeV3VaultLike, IAsyncRedeemManagerLike, ISpokeLike } from "./interfaces/CentrifugeInterfaces.sol";
@@ -75,27 +76,6 @@ contract ForeignController is AccessControl {
 
     bytes32 public FREEZER = keccak256("FREEZER");
     bytes32 public RELAYER = keccak256("RELAYER");
-
-    bytes32 public LIMIT_4626_DEPOSIT        = keccak256("LIMIT_4626_DEPOSIT");
-    bytes32 public LIMIT_4626_WITHDRAW       = keccak256("LIMIT_4626_WITHDRAW");
-    bytes32 public LIMIT_7540_DEPOSIT        = keccak256("LIMIT_7540_DEPOSIT");
-    bytes32 public LIMIT_7540_REDEEM         = keccak256("LIMIT_7540_REDEEM");
-    bytes32 public LIMIT_AAVE_DEPOSIT        = keccak256("LIMIT_AAVE_DEPOSIT");
-    bytes32 public LIMIT_AAVE_WITHDRAW       = keccak256("LIMIT_AAVE_WITHDRAW");
-    bytes32 public LIMIT_ASSET_TRANSFER      = keccak256("LIMIT_ASSET_TRANSFER");
-    bytes32 public LIMIT_CENTRIFUGE_TRANSFER = keccak256("LIMIT_CENTRIFUGE_TRANSFER");
-    bytes32 public LIMIT_CURVE_DEPOSIT       = keccak256("LIMIT_CURVE_DEPOSIT");
-    bytes32 public LIMIT_CURVE_SWAP          = keccak256("LIMIT_CURVE_SWAP");
-    bytes32 public LIMIT_CURVE_WITHDRAW      = keccak256("LIMIT_CURVE_WITHDRAW");
-    bytes32 public LIMIT_LAYERZERO_TRANSFER  = keccak256("LIMIT_LAYERZERO_TRANSFER");
-    bytes32 public LIMIT_PENDLE_PT_REDEEM    = keccak256("LIMIT_PENDLE_PT_REDEEM");
-    bytes32 public LIMIT_PSM_DEPOSIT         = keccak256("LIMIT_PSM_DEPOSIT");
-    bytes32 public LIMIT_PSM_WITHDRAW        = keccak256("LIMIT_PSM_WITHDRAW");
-    bytes32 public LIMIT_USDC_TO_CCTP        = keccak256("LIMIT_USDC_TO_CCTP");
-    bytes32 public LIMIT_USDC_TO_DOMAIN      = keccak256("LIMIT_USDC_TO_DOMAIN");
-    bytes32 public LIMIT_UNISWAP_V3_DEPOSIT  = keccak256("LIMIT_UNISWAP_V3_DEPOSIT");
-    bytes32 public LIMIT_UNISWAP_V3_SWAP     = keccak256("LIMIT_UNISWAP_V3_SWAP");
-    bytes32 public LIMIT_UNISWAP_V3_WITHDRAW = keccak256("LIMIT_UNISWAP_V3_WITHDRAW");
 
     uint256 internal CENTRIFUGE_REQUEST_ID = 0;
 
@@ -284,7 +264,7 @@ contract ForeignController is AccessControl {
     function depositPSM(address asset, uint256 amount)
         external
         onlyRole(RELAYER)
-        rateLimitedAsset(LIMIT_PSM_DEPOSIT, asset, amount)
+        rateLimitedAsset(RateLimitKeysLib.LIMIT_PSM_DEPOSIT, asset, amount)
         returns (uint256 shares)
     {
         // Approve `asset` to PSM from the proxy (assumes the proxy has enough `asset`).
@@ -323,7 +303,7 @@ contract ForeignController is AccessControl {
         );
 
         rateLimits.triggerRateLimitDecrease(
-            RateLimitHelpers.makeAssetKey(LIMIT_PSM_WITHDRAW, asset),
+            RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_PSM_WITHDRAW, asset),
             assetsWithdrawn
         );
     }
@@ -340,8 +320,8 @@ contract ForeignController is AccessControl {
             rateLimits        : rateLimits,
             cctp              : cctp,
             usdc              : usdc,
-            domainRateLimitId : LIMIT_USDC_TO_DOMAIN,
-            cctpRateLimitId   : LIMIT_USDC_TO_CCTP,
+            domainRateLimitId : RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
+            cctpRateLimitId   : RateLimitKeysLib.LIMIT_USDC_TO_CCTP,
             mintRecipient     : mintRecipients[destinationDomain],
             destinationDomain : destinationDomain,
             usdcAmount        : usdcAmount
@@ -360,7 +340,7 @@ contract ForeignController is AccessControl {
     {
         _checkRole(RELAYER);
         _rateLimited(
-            keccak256(abi.encode(LIMIT_LAYERZERO_TRANSFER, oftAddress, destinationEndpointId)),
+            keccak256(abi.encode(RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER, oftAddress, destinationEndpointId)),
             amount
         );
 
@@ -403,7 +383,7 @@ contract ForeignController is AccessControl {
     function transferAsset(address asset, address destination, uint256 amount) external {
         _checkRole(RELAYER);
         _rateLimited(
-            RateLimitHelpers.makeAssetDestinationKey(LIMIT_ASSET_TRANSFER, asset, destination),
+            RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_ASSET_TRANSFER, asset, destination),
             amount
         );
 
@@ -417,7 +397,7 @@ contract ForeignController is AccessControl {
     function depositERC4626(address token, uint256 amount)
         external
         onlyRole(RELAYER)
-        rateLimitedAsset(LIMIT_4626_DEPOSIT, token, amount)
+        rateLimitedAsset(RateLimitKeysLib.LIMIT_4626_DEPOSIT, token, amount)
         returns (uint256 shares)
     {
         // Note that whitelist is done by rate limits.
@@ -444,7 +424,7 @@ contract ForeignController is AccessControl {
     function withdrawERC4626(address token, uint256 amount)
         external
         onlyRole(RELAYER)
-        rateLimitedAsset(LIMIT_4626_WITHDRAW, token, amount)
+        rateLimitedAsset(RateLimitKeysLib.LIMIT_4626_WITHDRAW, token, amount)
         returns (uint256 shares)
     {
         // Withdraw asset from a token, decode resulting shares.
@@ -475,7 +455,7 @@ contract ForeignController is AccessControl {
         );
 
         rateLimits.triggerRateLimitDecrease(
-            RateLimitHelpers.makeAssetKey(LIMIT_4626_WITHDRAW, token),
+            RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_WITHDRAW, token),
             assets
         );
     }
@@ -487,7 +467,7 @@ contract ForeignController is AccessControl {
     function requestDepositERC7540(address token, uint256 amount)
         external
         onlyRole(RELAYER)
-        rateLimitedAsset(LIMIT_7540_DEPOSIT, token, amount)
+        rateLimitedAsset(RateLimitKeysLib.LIMIT_7540_DEPOSIT, token, amount)
     {
 
         // Note that whitelist is done by rate limits
@@ -506,7 +486,7 @@ contract ForeignController is AccessControl {
     function claimDepositERC7540(address token)
         external
         onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token))
+        rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_DEPOSIT, token))
     {
 
         uint256 shares = IERC7540(token).maxMint(address(proxy));
@@ -521,7 +501,7 @@ contract ForeignController is AccessControl {
     function requestRedeemERC7540(address token, uint256 shares)
         external
         onlyRole(RELAYER)
-        rateLimitedAsset(LIMIT_7540_REDEEM, token, IERC7540(token).convertToAssets(shares))
+        rateLimitedAsset(RateLimitKeysLib.LIMIT_7540_REDEEM, token, IERC7540(token).convertToAssets(shares))
     {
         // Submit redeem request by transferring shares
         proxy.doCall(
@@ -533,7 +513,7 @@ contract ForeignController is AccessControl {
     function claimRedeemERC7540(address token)
         external
         onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token))
+        rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_REDEEM, token))
     {
         uint256 assets = IERC7540(token).maxWithdraw(address(proxy));
 
@@ -553,7 +533,7 @@ contract ForeignController is AccessControl {
     function cancelCentrifugeDepositRequest(address token)
         external
         onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token))
+        rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_DEPOSIT, token))
     {
         // NOTE: While the cancelation is pending, no new deposit request can be submitted
         proxy.doCall(
@@ -568,7 +548,7 @@ contract ForeignController is AccessControl {
     function claimCentrifugeCancelDepositRequest(address token)
         external
         onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token))
+        rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_DEPOSIT, token))
     {
         proxy.doCall(
             token,
@@ -582,7 +562,7 @@ contract ForeignController is AccessControl {
     function cancelCentrifugeRedeemRequest(address token)
         external
         onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token))
+        rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_REDEEM, token))
     {
         // NOTE: While the cancelation is pending, no new redeem request can be submitted
         proxy.doCall(
@@ -597,7 +577,7 @@ contract ForeignController is AccessControl {
     function claimCentrifugeCancelRedeemRequest(address token)
         external
         onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token))
+        rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_REDEEM, token))
     {
         proxy.doCall(
             token,
@@ -623,7 +603,7 @@ contract ForeignController is AccessControl {
             amount                  : amount,
             recipient               : centrifugeRecipients[destinationCentrifugeId],
             destinationCentrifugeId : destinationCentrifugeId,
-            rateLimitId             : LIMIT_CENTRIFUGE_TRANSFER
+            rateLimitId             : RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER
         }));
     }
 
@@ -634,7 +614,7 @@ contract ForeignController is AccessControl {
     function depositAave(address aToken, uint256 amount)
         external
         onlyRole(RELAYER)
-        rateLimitedAsset(LIMIT_AAVE_DEPOSIT, aToken, amount)
+        rateLimitedAsset(RateLimitKeysLib.LIMIT_AAVE_DEPOSIT, aToken, amount)
     {
         require(maxSlippages[aToken] != 0, "FC/max-slippage-not-set");
 
@@ -682,7 +662,7 @@ contract ForeignController is AccessControl {
         );
 
         rateLimits.triggerRateLimitDecrease(
-            RateLimitHelpers.makeAssetKey(LIMIT_AAVE_WITHDRAW, aToken),
+            RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_AAVE_WITHDRAW, aToken),
             amountWithdrawn
         );
     }
@@ -706,7 +686,7 @@ contract ForeignController is AccessControl {
             proxy        : proxy,
             rateLimits   : rateLimits,
             pool         : pool,
-            rateLimitId  : LIMIT_CURVE_SWAP,
+            rateLimitId  : RateLimitKeysLib.LIMIT_CURVE_SWAP,
             inputIndex   : inputIndex,
             outputIndex  : outputIndex,
             amountIn     : amountIn,
@@ -728,8 +708,8 @@ contract ForeignController is AccessControl {
             proxy                   : proxy,
             rateLimits              : rateLimits,
             pool                    : pool,
-            addLiquidityRateLimitId : LIMIT_CURVE_DEPOSIT,
-            swapRateLimitId         : LIMIT_CURVE_SWAP,
+            addLiquidityRateLimitId : RateLimitKeysLib.LIMIT_CURVE_DEPOSIT,
+            swapRateLimitId         : RateLimitKeysLib.LIMIT_CURVE_SWAP,
             minLpAmount             : minLpAmount,
             maxSlippage             : maxSlippages[pool],
             depositAmounts          : depositAmounts
@@ -749,7 +729,7 @@ contract ForeignController is AccessControl {
             proxy              : proxy,
             rateLimits         : rateLimits,
             pool               : pool,
-            rateLimitId        : LIMIT_CURVE_WITHDRAW,
+            rateLimitId        : RateLimitKeysLib.LIMIT_CURVE_WITHDRAW,
             lpBurnAmount       : lpBurnAmount,
             minWithdrawAmounts : minWithdrawAmounts,
             maxSlippage        : maxSlippages[pool]
@@ -785,7 +765,7 @@ contract ForeignController is AccessControl {
         PendleLib.redeemPendlePT(PendleLib.RedeemPendlePTParams({
             proxy        : proxy,
             rateLimits   : rateLimits,
-            rateLimitId  : LIMIT_PENDLE_PT_REDEEM,
+            rateLimitId  : RateLimitKeysLib.LIMIT_PENDLE_PT_REDEEM,
             pendleMarket : IPendleMarket(pendleMarket),
             pendleRouter : pendleRouter,
             pyAmountIn   : pyAmountIn,
@@ -811,7 +791,7 @@ contract ForeignController is AccessControl {
             UniswapV3Lib.UniV3Context({
                 proxy       : proxy,
                 rateLimits  : rateLimits,
-                rateLimitId : LIMIT_UNISWAP_V3_SWAP,
+                rateLimitId : RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,
                 pool        : pool
             }),
             UniswapV3Lib.SwapParams({
@@ -846,7 +826,7 @@ contract ForeignController is AccessControl {
             UniswapV3Lib.UniV3Context({
                 proxy       : proxy,
                 rateLimits  : rateLimits,
-                rateLimitId : LIMIT_UNISWAP_V3_DEPOSIT,
+                rateLimitId : RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,
                 pool        : pool
             }),
             UniswapV3Lib.AddLiquidityParams({
@@ -878,7 +858,7 @@ contract ForeignController is AccessControl {
             UniswapV3Lib.UniV3Context({
                 proxy       : proxy,
                 rateLimits  : rateLimits,
-                rateLimitId : LIMIT_UNISWAP_V3_WITHDRAW,
+                rateLimitId : RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW,
                 pool        : pool
             }),
             UniswapV3Lib.RemoveLiquidityParams({

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -27,6 +27,7 @@ import { CurveLib }                       from "./libraries/CurveLib.sol";
 import { MerklLib }                       from "./libraries/MerklLib.sol";
 import { IDaiUsdsLike, IPSMLike, PSMLib } from "./libraries/PSMLib.sol";
 import { PendleLib }                      from "./libraries/PendleLib.sol";
+import { RateLimitKeysLib }               from "./libraries/RateLimitKeysLib.sol";
 import { ERC20Lib }                       from "./libraries/common/ERC20Lib.sol";
 import { UniswapV3Lib }                   from "./libraries/UniswapV3Lib.sol";
 
@@ -82,30 +83,6 @@ contract MainnetController is AccessControl {
 
     bytes32 public FREEZER = keccak256("FREEZER");
     bytes32 public RELAYER = keccak256("RELAYER");
-
-    bytes32 public LIMIT_4626_DEPOSIT         = keccak256("LIMIT_4626_DEPOSIT");
-    bytes32 public LIMIT_4626_WITHDRAW        = keccak256("LIMIT_4626_WITHDRAW");
-    bytes32 public LIMIT_7540_DEPOSIT         = keccak256("LIMIT_7540_DEPOSIT");
-    bytes32 public LIMIT_7540_REDEEM          = keccak256("LIMIT_7540_REDEEM");
-    bytes32 public LIMIT_AAVE_DEPOSIT         = keccak256("LIMIT_AAVE_DEPOSIT");
-    bytes32 public LIMIT_AAVE_WITHDRAW        = keccak256("LIMIT_AAVE_WITHDRAW");
-    bytes32 public LIMIT_ASSET_TRANSFER       = keccak256("LIMIT_ASSET_TRANSFER");
-    bytes32 public LIMIT_CENTRIFUGE_TRANSFER  = keccak256("LIMIT_CENTRIFUGE_TRANSFER");
-    bytes32 public LIMIT_CURVE_DEPOSIT        = keccak256("LIMIT_CURVE_DEPOSIT");
-    bytes32 public LIMIT_CURVE_SWAP           = keccak256("LIMIT_CURVE_SWAP");
-    bytes32 public LIMIT_CURVE_WITHDRAW       = keccak256("LIMIT_CURVE_WITHDRAW");
-    bytes32 public LIMIT_LAYERZERO_TRANSFER   = keccak256("LIMIT_LAYERZERO_TRANSFER");
-    bytes32 public LIMIT_PENDLE_PT_REDEEM     = keccak256("LIMIT_PENDLE_PT_REDEEM");
-    bytes32 public LIMIT_SUSDE_COOLDOWN       = keccak256("LIMIT_SUSDE_COOLDOWN");
-    bytes32 public LIMIT_USDC_TO_CCTP         = keccak256("LIMIT_USDC_TO_CCTP");
-    bytes32 public LIMIT_USDC_TO_DOMAIN       = keccak256("LIMIT_USDC_TO_DOMAIN");
-    bytes32 public LIMIT_USDE_BURN            = keccak256("LIMIT_USDE_BURN");
-    bytes32 public LIMIT_USDE_MINT            = keccak256("LIMIT_USDE_MINT");
-    bytes32 public LIMIT_USDS_MINT            = keccak256("LIMIT_USDS_MINT");
-    bytes32 public LIMIT_USDS_TO_USDC         = keccak256("LIMIT_USDS_TO_USDC");
-    bytes32 public LIMIT_UNISWAP_V3_DEPOSIT   = keccak256("LIMIT_UNISWAP_V3_DEPOSIT");
-    bytes32 public LIMIT_UNISWAP_V3_SWAP      = keccak256("LIMIT_UNISWAP_V3_SWAP");
-    bytes32 public LIMIT_UNISWAP_V3_WITHDRAW  = keccak256("LIMIT_UNISWAP_V3_WITHDRAW");
 
     uint256 internal CENTRIFUGE_REQUEST_ID = 0;
 
@@ -282,7 +259,7 @@ contract MainnetController is AccessControl {
 
     function mintUSDS(uint256 usdsAmount) external {
         _checkRole(RELAYER);
-        _rateLimited(LIMIT_USDS_MINT, usdsAmount);
+        _rateLimited(RateLimitKeysLib.LIMIT_USDS_MINT, usdsAmount);
 
         // Mint USDS into the buffer
         proxy.doCall(
@@ -299,7 +276,7 @@ contract MainnetController is AccessControl {
 
     function burnUSDS(uint256 usdsAmount) external {
         _checkRole(RELAYER);
-        _cancelRateLimit(LIMIT_USDS_MINT, usdsAmount);
+        _cancelRateLimit(RateLimitKeysLib.LIMIT_USDS_MINT, usdsAmount);
 
         // Transfer USDS from the proxy to the buffer
         ERC20Lib.transfer(proxy, address(usds), buffer, usdsAmount);
@@ -318,7 +295,7 @@ contract MainnetController is AccessControl {
     function transferAsset(address asset, address destination, uint256 amount) external {
         _checkRole(RELAYER);
         _rateLimited(
-            RateLimitHelpers.makeAssetDestinationKey(LIMIT_ASSET_TRANSFER, asset, destination),
+            RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_ASSET_TRANSFER, asset, destination),
             amount
         );
 
@@ -331,7 +308,7 @@ contract MainnetController is AccessControl {
 
     function depositERC4626(address token, uint256 amount) external returns (uint256 shares) {
         _checkRole(RELAYER);
-        _rateLimitedAsset(LIMIT_4626_DEPOSIT, token, amount);
+        _rateLimitedAsset(RateLimitKeysLib.LIMIT_4626_DEPOSIT, token, amount);
 
         // Note that whitelist is done by rate limits
         IERC20 asset = IERC20(IERC4626(token).asset());
@@ -356,7 +333,7 @@ contract MainnetController is AccessControl {
 
     function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares) {
         _checkRole(RELAYER);
-        _rateLimitedAsset(LIMIT_4626_WITHDRAW, token, amount);
+        _rateLimitedAsset(RateLimitKeysLib.LIMIT_4626_WITHDRAW, token, amount);
 
         // Withdraw asset from a token, decode resulting shares.
         // Assumes proxy has adequate token shares.
@@ -384,7 +361,7 @@ contract MainnetController is AccessControl {
         );
 
         rateLimits.triggerRateLimitDecrease(
-            RateLimitHelpers.makeAssetKey(LIMIT_4626_WITHDRAW, token),
+            RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_WITHDRAW, token),
             assets
         );
     }
@@ -395,7 +372,7 @@ contract MainnetController is AccessControl {
 
     function requestDepositERC7540(address token, uint256 amount) external {
         _checkRole(RELAYER);
-        _rateLimitedAsset(LIMIT_7540_DEPOSIT, token, amount);
+        _rateLimitedAsset(RateLimitKeysLib.LIMIT_7540_DEPOSIT, token, amount);
 
         // Note that whitelist is done by rate limits
         IERC20 asset = IERC20(IERC7540(token).asset());
@@ -412,7 +389,7 @@ contract MainnetController is AccessControl {
 
     function claimDepositERC7540(address token) external {
         _checkRole(RELAYER);
-        _rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token));
+        _rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_DEPOSIT, token));
 
         uint256 shares = IERC7540(token).maxMint(address(proxy));
 
@@ -426,7 +403,7 @@ contract MainnetController is AccessControl {
     function requestRedeemERC7540(address token, uint256 shares) external {
         _checkRole(RELAYER);
         _rateLimitedAsset(
-            LIMIT_7540_REDEEM,
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             token,
             IERC7540(token).convertToAssets(shares)
         );
@@ -440,7 +417,7 @@ contract MainnetController is AccessControl {
 
     function claimRedeemERC7540(address token) external {
         _checkRole(RELAYER);
-        _rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token));
+        _rateLimitExists(RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_7540_REDEEM, token));
 
         uint256 assets = IERC7540(token).maxWithdraw(address(proxy));
 
@@ -493,7 +470,7 @@ contract MainnetController is AccessControl {
                 amount                  : amount,
                 recipient               : centrifugeRecipients[destinationCentrifugeId],
                 destinationCentrifugeId : destinationCentrifugeId,
-                rateLimitId             : LIMIT_CENTRIFUGE_TRANSFER
+                rateLimitId             : RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER
             })
         );
     }
@@ -504,7 +481,7 @@ contract MainnetController is AccessControl {
 
     function depositAave(address aToken, uint256 amount) external {
         _checkRole(RELAYER);
-        _rateLimitedAsset(LIMIT_AAVE_DEPOSIT, aToken, amount);
+        _rateLimitedAsset(RateLimitKeysLib.LIMIT_AAVE_DEPOSIT, aToken, amount);
 
         require(maxSlippages[aToken] != 0, "MC/max-slippage-not-set");
 
@@ -553,7 +530,7 @@ contract MainnetController is AccessControl {
         );
 
         rateLimits.triggerRateLimitDecrease(
-            RateLimitHelpers.makeAssetKey(LIMIT_AAVE_WITHDRAW, aToken),
+            RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_AAVE_WITHDRAW, aToken),
             amountWithdrawn
         );
     }
@@ -577,7 +554,7 @@ contract MainnetController is AccessControl {
             proxy        : proxy,
             rateLimits   : rateLimits,
             pool         : pool,
-            rateLimitId  : LIMIT_CURVE_SWAP,
+            rateLimitId  : RateLimitKeysLib.LIMIT_CURVE_SWAP,
             inputIndex   : inputIndex,
             outputIndex  : outputIndex,
             amountIn     : amountIn,
@@ -599,8 +576,8 @@ contract MainnetController is AccessControl {
             proxy                   : proxy,
             rateLimits              : rateLimits,
             pool                    : pool,
-            addLiquidityRateLimitId : LIMIT_CURVE_DEPOSIT,
-            swapRateLimitId         : LIMIT_CURVE_SWAP,
+            addLiquidityRateLimitId : RateLimitKeysLib.LIMIT_CURVE_DEPOSIT,
+            swapRateLimitId         : RateLimitKeysLib.LIMIT_CURVE_SWAP,
             minLpAmount             : minLpAmount,
             maxSlippage             : maxSlippages[pool],
             depositAmounts          : depositAmounts
@@ -620,7 +597,7 @@ contract MainnetController is AccessControl {
             proxy              : proxy,
             rateLimits         : rateLimits,
             pool               : pool,
-            rateLimitId        : LIMIT_CURVE_WITHDRAW,
+            rateLimitId        : RateLimitKeysLib.LIMIT_CURVE_WITHDRAW,
             lpBurnAmount       : lpBurnAmount,
             minWithdrawAmounts : minWithdrawAmounts,
             maxSlippage        : maxSlippages[pool]
@@ -645,7 +622,7 @@ contract MainnetController is AccessControl {
             UniswapV3Lib.UniV3Context({
                 proxy       : proxy,
                 rateLimits  : rateLimits,
-                rateLimitId : LIMIT_UNISWAP_V3_SWAP,
+                rateLimitId : RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,
                 pool        : pool
             }),
             UniswapV3Lib.SwapParams({
@@ -679,7 +656,7 @@ contract MainnetController is AccessControl {
             UniswapV3Lib.UniV3Context({
                 proxy       : proxy,
                 rateLimits  : rateLimits,
-                rateLimitId : LIMIT_UNISWAP_V3_DEPOSIT,
+                rateLimitId : RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,
                 pool        : pool
             }),
             UniswapV3Lib.AddLiquidityParams({
@@ -711,7 +688,7 @@ contract MainnetController is AccessControl {
             UniswapV3Lib.UniV3Context({
                 proxy       : proxy,
                 rateLimits  : rateLimits,
-                rateLimitId : LIMIT_UNISWAP_V3_WITHDRAW,
+                rateLimitId : RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW,
                 pool        : pool
             }),
             UniswapV3Lib.RemoveLiquidityParams({
@@ -751,19 +728,19 @@ contract MainnetController is AccessControl {
     // Note that Ethena's mint/redeem per-block limits include other users
     function prepareUSDeMint(uint256 usdcAmount) external {
         _checkRole(RELAYER);
-        _rateLimited(LIMIT_USDE_MINT, usdcAmount);
+        _rateLimited(RateLimitKeysLib.LIMIT_USDE_MINT, usdcAmount);
         ERC20Lib.approve(proxy, address(usdc), address(ethenaMinter), usdcAmount);
     }
 
     function prepareUSDeBurn(uint256 usdeAmount) external {
         _checkRole(RELAYER);
-        _rateLimited(LIMIT_USDE_BURN, usdeAmount);
+        _rateLimited(RateLimitKeysLib.LIMIT_USDE_BURN, usdeAmount);
         ERC20Lib.approve(proxy, address(usde), address(ethenaMinter), usdeAmount);
     }
 
     function cooldownAssetsSUSDe(uint256 usdeAmount) external {
         _checkRole(RELAYER);
-        _rateLimited(LIMIT_SUSDE_COOLDOWN, usdeAmount);
+        _rateLimited(RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN, usdeAmount);
 
         proxy.doCall(
             address(susde),
@@ -786,7 +763,7 @@ contract MainnetController is AccessControl {
             (uint256)
         );
 
-        rateLimits.triggerRateLimitDecrease(LIMIT_SUSDE_COOLDOWN, cooldownAmount);
+        rateLimits.triggerRateLimitDecrease(RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN, cooldownAmount);
     }
 
     function unstakeSUSDe() external {
@@ -815,7 +792,7 @@ contract MainnetController is AccessControl {
         PendleLib.redeemPendlePT(PendleLib.RedeemPendlePTParams({
             proxy        : proxy,
             rateLimits   : rateLimits,
-            rateLimitId  : LIMIT_PENDLE_PT_REDEEM,
+            rateLimitId  : RateLimitKeysLib.LIMIT_PENDLE_PT_REDEEM,
             pendleMarket : IPendleMarket(pendleMarket),
             pendleRouter : Ethereum.PENDLE_ROUTER,
             pyAmountIn   : pyAmountIn,
@@ -871,7 +848,7 @@ contract MainnetController is AccessControl {
             psm                     : psm,
             usds                    : usds,
             dai                     : dai,
-            rateLimitId             : LIMIT_USDS_TO_USDC,
+            rateLimitId             : RateLimitKeysLib.LIMIT_USDS_TO_USDC,
             usdcAmount              : usdcAmount,
             psmTo18ConversionFactor : psmTo18ConversionFactor
         }));
@@ -887,7 +864,7 @@ contract MainnetController is AccessControl {
             psm                     : psm,
             dai                     : dai,
             usdc                    : usdc,
-            rateLimitId             : LIMIT_USDS_TO_USDC,
+            rateLimitId             : RateLimitKeysLib.LIMIT_USDS_TO_USDC,
             usdcAmount              : usdcAmount,
             psmTo18ConversionFactor : psmTo18ConversionFactor
         }));
@@ -905,7 +882,7 @@ contract MainnetController is AccessControl {
     {
         _checkRole(RELAYER);
         _rateLimited(
-            keccak256(abi.encode(LIMIT_LAYERZERO_TRANSFER, oftAddress, destinationEndpointId)),
+            keccak256(abi.encode(RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER, oftAddress, destinationEndpointId)),
             amount
         );
 
@@ -967,8 +944,8 @@ contract MainnetController is AccessControl {
             rateLimits        : rateLimits,
             cctp              : cctp,
             usdc              : usdc,
-            domainRateLimitId : LIMIT_USDC_TO_DOMAIN,
-            cctpRateLimitId   : LIMIT_USDC_TO_CCTP,
+            domainRateLimitId : RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
+            cctpRateLimitId   : RateLimitKeysLib.LIMIT_USDC_TO_CCTP,
             mintRecipient     : mintRecipients[destinationDomain],
             destinationDomain : destinationDomain,
             usdcAmount        : usdcAmount
@@ -1009,7 +986,7 @@ contract MainnetController is AccessControl {
             proxy       : proxy,
             rateLimits  : rateLimits,
             token       : token,
-            rateLimitId : LIMIT_7540_DEPOSIT,
+            rateLimitId : RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             requestId   : CENTRIFUGE_REQUEST_ID
         });
     }
@@ -1021,7 +998,7 @@ contract MainnetController is AccessControl {
             proxy       : proxy,
             rateLimits  : rateLimits,
             token       : token,
-            rateLimitId : LIMIT_7540_REDEEM,
+            rateLimitId : RateLimitKeysLib.LIMIT_7540_REDEEM,
             requestId   : CENTRIFUGE_REQUEST_ID
         });
     }

--- a/src/libraries/RateLimitKeysLib.sol
+++ b/src/libraries/RateLimitKeysLib.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.21;
+
+library RateLimitKeysLib {
+
+    bytes32 internal constant LIMIT_4626_DEPOSIT         = keccak256("LIMIT_4626_DEPOSIT");
+    bytes32 internal constant LIMIT_4626_WITHDRAW        = keccak256("LIMIT_4626_WITHDRAW");
+    bytes32 internal constant LIMIT_7540_DEPOSIT         = keccak256("LIMIT_7540_DEPOSIT");
+    bytes32 internal constant LIMIT_7540_REDEEM          = keccak256("LIMIT_7540_REDEEM");
+    bytes32 internal constant LIMIT_AAVE_DEPOSIT         = keccak256("LIMIT_AAVE_DEPOSIT");
+    bytes32 internal constant LIMIT_AAVE_WITHDRAW        = keccak256("LIMIT_AAVE_WITHDRAW");
+    bytes32 internal constant LIMIT_ASSET_TRANSFER       = keccak256("LIMIT_ASSET_TRANSFER");
+    bytes32 internal constant LIMIT_CENTRIFUGE_TRANSFER  = keccak256("LIMIT_CENTRIFUGE_TRANSFER");
+    bytes32 internal constant LIMIT_CURVE_DEPOSIT        = keccak256("LIMIT_CURVE_DEPOSIT");
+    bytes32 internal constant LIMIT_CURVE_SWAP           = keccak256("LIMIT_CURVE_SWAP");
+    bytes32 internal constant LIMIT_CURVE_WITHDRAW       = keccak256("LIMIT_CURVE_WITHDRAW");
+    bytes32 internal constant LIMIT_LAYERZERO_TRANSFER   = keccak256("LIMIT_LAYERZERO_TRANSFER");
+    bytes32 internal constant LIMIT_PENDLE_PT_REDEEM     = keccak256("LIMIT_PENDLE_PT_REDEEM");
+    bytes32 internal constant LIMIT_PSM_DEPOSIT          = keccak256("LIMIT_PSM_DEPOSIT");
+    bytes32 internal constant LIMIT_PSM_WITHDRAW         = keccak256("LIMIT_PSM_WITHDRAW");
+    bytes32 internal constant LIMIT_SUSDE_COOLDOWN       = keccak256("LIMIT_SUSDE_COOLDOWN");
+    bytes32 internal constant LIMIT_USDC_TO_CCTP         = keccak256("LIMIT_USDC_TO_CCTP");
+    bytes32 internal constant LIMIT_USDC_TO_DOMAIN       = keccak256("LIMIT_USDC_TO_DOMAIN");
+    bytes32 internal constant LIMIT_USDE_BURN            = keccak256("LIMIT_USDE_BURN");
+    bytes32 internal constant LIMIT_USDE_MINT            = keccak256("LIMIT_USDE_MINT");
+    bytes32 internal constant LIMIT_USDS_MINT            = keccak256("LIMIT_USDS_MINT");
+    bytes32 internal constant LIMIT_USDS_TO_USDC         = keccak256("LIMIT_USDS_TO_USDC");
+    bytes32 internal constant LIMIT_UNISWAP_V3_DEPOSIT   = keccak256("LIMIT_UNISWAP_V3_DEPOSIT");
+    bytes32 internal constant LIMIT_UNISWAP_V3_SWAP      = keccak256("LIMIT_UNISWAP_V3_SWAP");
+    bytes32 internal constant LIMIT_UNISWAP_V3_WITHDRAW  = keccak256("LIMIT_UNISWAP_V3_WITHDRAW");
+
+}

--- a/test/grove-avalanche-fork/Centrifuge.t.sol
+++ b/test/grove-avalanche-fork/Centrifuge.t.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.0;
 
 import { ICentrifugeV3VaultLike, IAsyncRedeemManagerLike, ISpokeLike } from "../../src/interfaces/CentrifugeInterfaces.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 interface ICentrifugeV3ShareLike is IERC20 {
@@ -90,7 +92,7 @@ contract ForeignControllerRequestDepositERC7540FailureTests is CentrifugeTestBas
         vm.startPrank(GROVE_EXECUTOR);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_7540_DEPOSIT(),
+                RateLimitKeysLib.LIMIT_7540_DEPOSIT,
                 address(centrifugeV3Vault)
             ),
             1_000_000e6,
@@ -122,7 +124,7 @@ contract ForeignControllerRequestDepositERC7540SuccessTests is CentrifugeTestBas
         vaultTokenHook.updateMember(address(vaultToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(centrifugeV3Vault)
         );
 
@@ -189,7 +191,7 @@ contract ForeignControllerClaimDepositERC7540SuccessTests is CentrifugeTestBase 
         vaultTokenHook.updateMember(address(vaultToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(centrifugeV3Vault)
         );
 
@@ -360,7 +362,7 @@ contract ForeignControllerCancelCentrifugeDepositSuccessTests is CentrifugeTestB
         vaultTokenHook.updateMember(address(vaultToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(centrifugeV3Vault)
         );
 
@@ -416,7 +418,7 @@ contract ForeignControllerClaimCentrifugeCancelDepositSuccessTests is Centrifuge
         vaultTokenHook.updateMember(address(vaultToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(centrifugeV3Vault)
         );
 
@@ -503,7 +505,7 @@ contract ForeignControllerRequestRedeemERC7540FailureTests is CentrifugeTestBase
         vm.startPrank(GROVE_EXECUTOR);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_7540_REDEEM(),
+                RateLimitKeysLib.LIMIT_7540_REDEEM,
                 address(centrifugeV3Vault)
             ),
             500_000e6,
@@ -541,7 +543,7 @@ contract ForeignControllerRequestRedeemERC7540SuccessTests is CentrifugeTestBase
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(centrifugeV3Vault)
         );
 
@@ -610,7 +612,7 @@ contract ForeignControllerClaimRedeemERC7540SuccessTests is CentrifugeTestBase {
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(centrifugeV3Vault)
         );
 
@@ -813,7 +815,7 @@ contract ForeignControllerCancelCentrifugeRedeemRequestSuccessTests is Centrifug
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(centrifugeV3Vault)
         );
 
@@ -873,7 +875,7 @@ contract ForeignControllerClaimCentrifugeCancelRedeemRequestSuccessTests is Cent
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(centrifugeV3Vault)
         );
 
@@ -961,7 +963,7 @@ contract ForeignControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
 
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                foreignController.LIMIT_CENTRIFUGE_TRANSFER(),
+                RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER,
                 CENTRIFUGE_VAULT,
                 DESTINATION_CENTRIFUGE_ID
             )),
@@ -997,7 +999,7 @@ contract ForeignControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
 
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                foreignController.LIMIT_CENTRIFUGE_TRANSFER(),
+                RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER,
                 CENTRIFUGE_VAULT,
                 DESTINATION_CENTRIFUGE_ID
             )),
@@ -1040,7 +1042,7 @@ contract ForeignControllerTransferSharesCentrifugeSuccessTests is CentrifugeTest
 
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                foreignController.LIMIT_CENTRIFUGE_TRANSFER(),
+                RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER,
                 CENTRIFUGE_VAULT,
                 DESTINATION_CENTRIFUGE_ID
             )),

--- a/test/grove-base-fork/Curve.t.sol
+++ b/test/grove-base-fork/Curve.t.sol
@@ -5,6 +5,8 @@ import { MockERC20Decimals } from "../unit/mocks/MockTokens.sol";
 
 import { ICurvePoolLike as ICurvePoolLikeLib } from "../../src/libraries/CurveLib.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 interface ICurvePoolLike is ICurvePoolLikeLib {
@@ -56,9 +58,9 @@ contract CurveTestBase is ForkTestBase {
             ICurvePoolLike(CURVE_POOL).add_liquidity(amounts, 1e18, address(this));
         }
 
-        curveDepositKey  = RateLimitHelpers.makeAssetKey(foreignController.LIMIT_CURVE_DEPOSIT(),  CURVE_POOL);
-        curveSwapKey     = RateLimitHelpers.makeAssetKey(foreignController.LIMIT_CURVE_SWAP(),     CURVE_POOL);
-        curveWithdrawKey = RateLimitHelpers.makeAssetKey(foreignController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        curveDepositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_DEPOSIT,  CURVE_POOL);
+        curveSwapKey     = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_SWAP,     CURVE_POOL);
+        curveWithdrawKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         vm.startPrank(GROVE_EXECUTOR);
         rateLimits.setRateLimitData(curveDepositKey,  2_000_000e18, uint256(2_000_000e18) / 1 days);
@@ -215,7 +217,7 @@ contract ForeignControllerAddLiquidityCurveFailureTests is CurveTestBase {
     }
 
     function test_addLiquidityCurve_zeroMaxAmount() public {
-        bytes32 curveDeposit = RateLimitHelpers.makeAssetKey(foreignController.LIMIT_CURVE_DEPOSIT(), CURVE_POOL);
+        bytes32 curveDeposit = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_DEPOSIT, CURVE_POOL);
 
         vm.prank(GROVE_EXECUTOR);
         rateLimits.setRateLimitData(curveDeposit, 0, 0);
@@ -511,7 +513,7 @@ contract ForeignControllerRemoveLiquidityCurveFailureTests is CurveTestBase {
     }
 
     function test_removeLiquidityCurve_zeroMaxAmount() public {
-        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(foreignController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         vm.prank(GROVE_EXECUTOR);
         rateLimits.setRateLimitData(curveWithdraw, 0, 0);
@@ -540,7 +542,7 @@ contract ForeignControllerRemoveLiquidityCurveFailureTests is CurveTestBase {
 
         vm.revertToState(id);
 
-        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(foreignController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         // Set to below boundary
         vm.prank(GROVE_EXECUTOR);
@@ -708,7 +710,7 @@ contract ForeignControllerSwapCurveFailureTests is CurveTestBase {
     }
 
     function test_swapCurve_zeroMaxAmount() public {
-        bytes32 curveSwap = RateLimitHelpers.makeAssetKey(foreignController.LIMIT_CURVE_SWAP(), CURVE_POOL);
+        bytes32 curveSwap = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_SWAP, CURVE_POOL);
 
         vm.prank(GROVE_EXECUTOR);
         rateLimits.setRateLimitData(curveSwap, 0, 0);

--- a/test/grove-base-fork/Pendle.t.sol
+++ b/test/grove-base-fork/Pendle.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.21;
 
 import { IPendleMarket, ISY, IYT } from "../../src/interfaces/PendleInterfaces.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract PendleTestBase is ForkTestBase {
@@ -18,7 +20,7 @@ contract PendleTestBase is ForkTestBase {
         super.setUp();
 
         redeemKey = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_PENDLE_PT_REDEEM(),
+            RateLimitKeysLib.LIMIT_PENDLE_PT_REDEEM,
             address(pendleMarket)
         );
 

--- a/test/grove-base-fork/TransferAsset.t.sol
+++ b/test/grove-base-fork/TransferAsset.t.sol
@@ -5,6 +5,8 @@ import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
 
 import { MockTokenReturnFalse, MockTokenReturnNull } from "../unit/mocks/MockTokens.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract TransferAssetBaseTest is ForkTestBase {
@@ -18,7 +20,7 @@ contract TransferAssetBaseTest is ForkTestBase {
 
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetDestinationKey(
-                foreignController.LIMIT_ASSET_TRANSFER(),
+                RateLimitKeysLib.LIMIT_ASSET_TRANSFER,
                 address(usdcBase),
                 receiver
             ),
@@ -65,7 +67,7 @@ contract ForeignControllerTransferAssetFailureTests is TransferAssetBaseTest {
 
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetDestinationKey(
-                foreignController.LIMIT_ASSET_TRANSFER(),
+                RateLimitKeysLib.LIMIT_ASSET_TRANSFER,
                 address(token),
                 receiver
             ),
@@ -106,7 +108,7 @@ contract ForeignControllerTransferAssetSuccessTests is TransferAssetBaseTest {
 
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetDestinationKey(
-                foreignController.LIMIT_ASSET_TRANSFER(),
+                RateLimitKeysLib.LIMIT_ASSET_TRANSFER,
                 address(token),
                 receiver
             ),

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -10,6 +10,7 @@ import { FullMath }   from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
 import { TickMath }   from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
 
 import { INonfungiblePositionManager, IUniswapV3PoolLike, UniswapV3Lib } from "../../src/libraries/UniswapV3Lib.sol";
+import { RateLimitKeysLib }                                              from "../../src/libraries/RateLimitKeysLib.sol";
 
 import "./ForkTestBase.t.sol";
 
@@ -79,19 +80,19 @@ contract UniswapV3TestBase is ForkTestBase {
 
         vm.warp(block.timestamp + 2 hours); // Advance sufficient time for twap
 
-        uniswapV3_UsdsUsdcPool_UsdsSwapKey            = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_SWAP(),     address(usdsBase), usdsUsdcPool);
-        uniswapV3_UsdsUsdcPool_UsdcSwapKey            = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_SWAP(),     address(usdcBase), usdsUsdcPool);
-        uniswapV3_UsdsUsdcPool_UsdsAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(usdsBase), usdsUsdcPool);
-        uniswapV3_UsdsUsdcPool_UsdcAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(usdcBase), usdsUsdcPool);
-        uniswapV3_UsdsUsdcPool_UsdsRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_WITHDRAW(), address(usdsBase), usdsUsdcPool);
-        uniswapV3_UsdsUsdcPool_UsdcRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_WITHDRAW(), address(usdcBase), usdsUsdcPool);
+        uniswapV3_UsdsUsdcPool_UsdsSwapKey            = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(usdsBase), usdsUsdcPool);
+        uniswapV3_UsdsUsdcPool_UsdcSwapKey            = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(usdcBase), usdsUsdcPool);
+        uniswapV3_UsdsUsdcPool_UsdsAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(usdsBase), usdsUsdcPool);
+        uniswapV3_UsdsUsdcPool_UsdcAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(usdcBase), usdsUsdcPool);
+        uniswapV3_UsdsUsdcPool_UsdsRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(usdsBase), usdsUsdcPool);
+        uniswapV3_UsdsUsdcPool_UsdcRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(usdcBase), usdsUsdcPool);
 
-        uniswapV3_AusdUsdsPool_AusdSwapKey            = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_SWAP(),     address(ausdBase), usdsAusdPool);
-        uniswapV3_AusdUsdsPool_UsdsSwapKey            = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_SWAP(),     address(usdsBase), usdsAusdPool);
-        uniswapV3_AusdUsdsPool_AusdAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(ausdBase), usdsAusdPool);
-        uniswapV3_AusdUsdsPool_UsdsAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(usdsBase), usdsAusdPool);
-        uniswapV3_AusdUsdsPool_AusdRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_WITHDRAW(), address(ausdBase), usdsAusdPool);
-        uniswapV3_AusdUsdsPool_UsdsRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_WITHDRAW(), address(usdsBase), usdsAusdPool);
+        uniswapV3_AusdUsdsPool_AusdSwapKey            = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(ausdBase), usdsAusdPool);
+        uniswapV3_AusdUsdsPool_UsdsSwapKey            = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(usdsBase), usdsAusdPool);
+        uniswapV3_AusdUsdsPool_AusdAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(ausdBase), usdsAusdPool);
+        uniswapV3_AusdUsdsPool_UsdsAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(usdsBase), usdsAusdPool);
+        uniswapV3_AusdUsdsPool_AusdRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(ausdBase), usdsAusdPool);
+        uniswapV3_AusdUsdsPool_UsdsRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(usdsBase), usdsAusdPool);
 
         vm.startPrank(GROVE_EXECUTOR);
         rateLimits.setRateLimitData(uniswapV3_UsdsUsdcPool_UsdsSwapKey, 1_000_000e18, uint256(1_000_000e18) / 1 days);
@@ -157,7 +158,7 @@ contract UniswapV3TestBase is ForkTestBase {
 
 
     function _getSwapKey(address tokenIn) internal view returns (bytes32) {
-        return RateLimitHelpers.makeAssetDestinationKey(foreignController.LIMIT_UNISWAP_V3_SWAP(), tokenIn, _getPool());
+        return RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP, tokenIn, _getPool());
     }
 
     function _label() internal {

--- a/test/grove-mainnet-fork/4626Calls.t.sol
+++ b/test/grove-mainnet-fork/4626Calls.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.0;
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract SUSDSTestBase is ForkTestBase {
@@ -19,11 +21,11 @@ contract SUSDSTestBase is ForkTestBase {
     function setUp() override public {
         super.setUp();
 
-        depositKey  = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_4626_DEPOSIT(),  Ethereum.SUSDS);
-        withdrawKey = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_4626_WITHDRAW(), Ethereum.SUSDS);
+        depositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_DEPOSIT,  Ethereum.SUSDS);
+        withdrawKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_WITHDRAW, Ethereum.SUSDS);
 
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_MINT(), 10_000_000e18, uint256(10_000_000e18) / 4 hours);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_MINT, 10_000_000e18, uint256(10_000_000e18) / 4 hours);
         rateLimits.setRateLimitData(depositKey,  5_000_000e18, uint256(1_000_000e18) / 4 hours);
         rateLimits.setRateLimitData(withdrawKey, 5_000_000e18, uint256(1_000_000e18) / 4 hours);
         mainnetController.setMaxExchangeRate(address(susds), susds.convertToShares(1e18), 1.2e18);
@@ -244,7 +246,7 @@ contract MainnetControllerRedeemERC4626FailureTests is SUSDSTestBase {
         vm.startPrank(Ethereum.GROVE_PROXY);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_4626_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_4626_WITHDRAW,
                 Ethereum.SUSDS
             ),
             0,

--- a/test/grove-mainnet-fork/Aave.t.sol
+++ b/test/grove-mainnet-fork/Aave.t.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.0;
 
 import { IAToken } from "aave-v3-origin/src/core/contracts/interfaces/IAToken.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract AaveV3MainMarketBaseTest is ForkTestBase {
@@ -24,7 +26,7 @@ contract AaveV3MainMarketBaseTest is ForkTestBase {
 
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_AAVE_DEPOSIT(),
+                RateLimitKeysLib.LIMIT_AAVE_DEPOSIT,
                 ATOKEN_USDS
             ),
             25_000_000e18,
@@ -32,7 +34,7 @@ contract AaveV3MainMarketBaseTest is ForkTestBase {
         );
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_AAVE_DEPOSIT(),
+                RateLimitKeysLib.LIMIT_AAVE_DEPOSIT,
                 ATOKEN_USDC
             ),
             25_000_000e6,
@@ -40,7 +42,7 @@ contract AaveV3MainMarketBaseTest is ForkTestBase {
         );
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_AAVE_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
                 ATOKEN_USDS
             ),
             10_000_000e18,
@@ -48,7 +50,7 @@ contract AaveV3MainMarketBaseTest is ForkTestBase {
         );
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_AAVE_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
                 ATOKEN_USDC
             ),
             10_000_000e6,
@@ -189,7 +191,7 @@ contract AaveV3MainMarketWithdrawFailureTests is AaveV3MainMarketBaseTest {
         vm.startPrank(Ethereum.GROVE_PROXY);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_AAVE_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
                 ATOKEN_USDC
             ),
             0,
@@ -239,7 +241,7 @@ contract AaveV3MainMarketWithdrawSuccessTests is AaveV3MainMarketBaseTest {
 
     function test_withdrawAave_usds() public {
         bytes32 key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_AAVE_WITHDRAW(),
+            RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
             ATOKEN_USDS
         );
 
@@ -285,7 +287,7 @@ contract AaveV3MainMarketWithdrawSuccessTests is AaveV3MainMarketBaseTest {
 
     function test_withdrawAave_usds_unlimitedRateLimit() public {
         bytes32 key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_AAVE_WITHDRAW(),
+            RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
             ATOKEN_USDS
         );
         vm.prank(Ethereum.GROVE_PROXY);
@@ -320,7 +322,7 @@ contract AaveV3MainMarketWithdrawSuccessTests is AaveV3MainMarketBaseTest {
 
     function test_withdrawAave_usdc() public {
         bytes32 key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_AAVE_WITHDRAW(),
+            RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
             ATOKEN_USDC
         );
         deal(Ethereum.USDC, address(almProxy), 1_000_000e6);
@@ -365,7 +367,7 @@ contract AaveV3MainMarketWithdrawSuccessTests is AaveV3MainMarketBaseTest {
 
     function test_withdrawAave_usdc_unlimitedRateLimit() public {
         bytes32 key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_AAVE_WITHDRAW(),
+            RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
             ATOKEN_USDC
         );
         vm.prank(Ethereum.GROVE_PROXY);

--- a/test/grove-mainnet-fork/Centrifuge.t.sol
+++ b/test/grove-mainnet-fork/Centrifuge.t.sol
@@ -5,8 +5,9 @@ import { IERC7540 } from "forge-std/interfaces/IERC7540.sol";
 
 import { ICentrifugeV3VaultLike } from "../../src/interfaces/CentrifugeInterfaces.sol";
 
-import "./ForkTestBase.t.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
+import "./ForkTestBase.t.sol";
 
 interface IRestrictionManager {
     function updateMember(address token, address user, uint64 validUntil) external;
@@ -100,7 +101,7 @@ contract MainnetControllerRequestDepositERC7540FailureTests is CentrifugeTestBas
         vm.startPrank(Ethereum.GROVE_PROXY);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_7540_DEPOSIT(),
+                RateLimitKeysLib.LIMIT_7540_DEPOSIT,
                 address(jTreasuryVault)
             ),
             1_000_000e6,
@@ -132,7 +133,7 @@ contract MainnetControllerRequestDepositERC7540SuccessTests is CentrifugeTestBas
         restrictionManager.updateMember(address(jTreasuryToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(jTreasuryVault)
         );
 
@@ -199,7 +200,7 @@ contract MainnetControllerClaimDepositERC7540SuccessTests is CentrifugeTestBase 
         restrictionManager.updateMember(address(jTreasuryToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(jTreasuryVault)
         );
 
@@ -348,7 +349,7 @@ contract MainnetControllerCancelCentrifugeDepositSuccessTests is CentrifugeTestB
         restrictionManager.updateMember(address(jTreasuryToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(jTreasuryVault)
         );
 
@@ -404,7 +405,7 @@ contract MainnetControllerClaimCentrifugeCancelDepositSuccessTests is Centrifuge
         restrictionManager.updateMember(address(jTreasuryToken), address(almProxy), type(uint64).max);
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_DEPOSIT(),
+            RateLimitKeysLib.LIMIT_7540_DEPOSIT,
             address(jTreasuryVault)
         );
 
@@ -485,7 +486,7 @@ contract MainnetControllerRequestRedeemERC7540FailureTests is CentrifugeTestBase
         vm.startPrank(Ethereum.GROVE_PROXY);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                mainnetController.LIMIT_7540_REDEEM(),
+                RateLimitKeysLib.LIMIT_7540_REDEEM,
                 address(jTreasuryVault)
             ),
             1_000_000e6,
@@ -524,7 +525,7 @@ contract MainnetControllerRequestRedeemERC7540SuccessTests is CentrifugeTestBase
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(jTreasuryVault)
         );
 
@@ -593,7 +594,7 @@ contract MainnetControllerClaimRedeemERC7540SuccessTests is CentrifugeTestBase {
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(jTreasuryVault)
         );
 
@@ -758,7 +759,7 @@ contract MainnetControllerCancelCentrifugeRedeemRequestSuccessTests is Centrifug
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(jTreasuryVault)
         );
 
@@ -818,7 +819,7 @@ contract MainnetControllerClaimCentrifugeCancelRedeemRequestSuccessTests is Cent
         vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_7540_REDEEM(),
+            RateLimitKeysLib.LIMIT_7540_REDEEM,
             address(jTreasuryVault)
         );
 

--- a/test/grove-mainnet-fork/CentrifugeV3.t.sol
+++ b/test/grove-mainnet-fork/CentrifugeV3.t.sol
@@ -5,6 +5,8 @@ import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
 import { ICentrifugeV3VaultLike, IAsyncRedeemManagerLike } from "../../src/interfaces/CentrifugeInterfaces.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract CentrifugeTestBase is ForkTestBase {
@@ -66,7 +68,7 @@ contract MainnetControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
 
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                mainnetController.LIMIT_CENTRIFUGE_TRANSFER(),
+                RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER,
                 CENTRIFUGE_VAULT,
                 DESTINATION_CENTRIFUGE_ID
             )),
@@ -102,7 +104,7 @@ contract MainnetControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
 
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                mainnetController.LIMIT_CENTRIFUGE_TRANSFER(),
+                RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER,
                 CENTRIFUGE_VAULT,
                 DESTINATION_CENTRIFUGE_ID
             )),
@@ -145,7 +147,7 @@ contract MainnetControllerTransferSharesCentrifugeSuccessTests is CentrifugeTest
 
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                mainnetController.LIMIT_CENTRIFUGE_TRANSFER(),
+                RateLimitKeysLib.LIMIT_CENTRIFUGE_TRANSFER,
                 CENTRIFUGE_VAULT,
                 DESTINATION_CENTRIFUGE_ID
             )),

--- a/test/grove-mainnet-fork/Curve.t.sol
+++ b/test/grove-mainnet-fork/Curve.t.sol
@@ -5,7 +5,8 @@ import { IERC4626 } from "forge-std/interfaces/IERC4626.sol";
 
 import "./ForkTestBase.t.sol";
 
-import { ICurvePoolLike } from "../../src/libraries/CurveLib.sol";
+import { ICurvePoolLike }  from "../../src/libraries/CurveLib.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
 contract CurveTestBase is ForkTestBase {
 
@@ -22,9 +23,9 @@ contract CurveTestBase is ForkTestBase {
     function setUp() public virtual override  {
         super.setUp();
 
-        curveDepositKey  = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_DEPOSIT(),  CURVE_POOL);
-        curveSwapKey     = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_SWAP(),     CURVE_POOL);
-        curveWithdrawKey = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        curveDepositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_DEPOSIT,  CURVE_POOL);
+        curveSwapKey     = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_SWAP,     CURVE_POOL);
+        curveWithdrawKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(curveDepositKey,  2_000_000e18, uint256(2_000_000e18) / 1 days);
@@ -139,7 +140,7 @@ contract MainnetControllerAddLiquidityCurveFailureTests is CurveTestBase {
     }
 
     function test_addLiquidityCurve_zeroMaxAmount() public {
-        bytes32 curveDeposit = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_DEPOSIT(), CURVE_POOL);
+        bytes32 curveDeposit = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_DEPOSIT, CURVE_POOL);
 
         vm.prank(GROVE_PROXY);
         rateLimits.setRateLimitData(curveDeposit, 0, 0);
@@ -437,7 +438,7 @@ contract MainnetControllerRemoveLiquidityCurveFailureTests is CurveTestBase {
     }
 
     function test_removeLiquidityCurve_zeroMaxAmount() public {
-        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         vm.prank(GROVE_PROXY);
         rateLimits.setRateLimitData(curveWithdraw, 0, 0);
@@ -470,7 +471,7 @@ contract MainnetControllerRemoveLiquidityCurveFailureTests is CurveTestBase {
 
         vm.revertToState(id);
 
-        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        bytes32 curveWithdraw = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         // Set to below boundary
         vm.prank(GROVE_PROXY);
@@ -633,7 +634,7 @@ contract MainnetControllerSwapCurveFailureTests is CurveTestBase {
     }
 
     function test_swapCurve_zeroMaxAmount() public {
-        bytes32 curveSwap = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_SWAP(), CURVE_POOL);
+        bytes32 curveSwap = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_SWAP, CURVE_POOL);
 
         vm.prank(GROVE_PROXY);
         rateLimits.setRateLimitData(curveSwap, 0, 0);
@@ -781,9 +782,9 @@ contract MainnetController3PoolSwapRateLimitTest is ForkTestBase {
     function setUp() public virtual override  {
         super.setUp();
 
-        curveDepositKey  = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_DEPOSIT(),  CURVE_POOL);
-        curveSwapKey     = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_SWAP(),     CURVE_POOL);
-        curveWithdrawKey = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        curveDepositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_DEPOSIT,  CURVE_POOL);
+        curveSwapKey     = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_SWAP,     CURVE_POOL);
+        curveWithdrawKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(curveDepositKey,  5_000_000e18, uint256(5_000_000e18) / 1 days);
@@ -856,9 +857,9 @@ contract MainnetControllerSUsdsUsdtSwapRateLimitTest is ForkTestBase {
     function setUp() public virtual override  {
         super.setUp();
 
-        curveDepositKey  = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_DEPOSIT(),  CURVE_POOL);
-        curveSwapKey     = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_SWAP(),     CURVE_POOL);
-        curveWithdrawKey = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        curveDepositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_DEPOSIT,  CURVE_POOL);
+        curveSwapKey     = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_SWAP,     CURVE_POOL);
+        curveWithdrawKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(curveDepositKey,  5_000_000e18, uint256(5_000_000e18) / 1 days);
@@ -1068,9 +1069,9 @@ contract MainnetControllerE2ECurveSUsdsUsdtPoolTest is ForkTestBase {
     function setUp() public virtual override  {
         super.setUp();
 
-        curveDepositKey  = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_DEPOSIT(),  CURVE_POOL);
-        curveSwapKey     = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_SWAP(),     CURVE_POOL);
-        curveWithdrawKey = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_CURVE_WITHDRAW(), CURVE_POOL);
+        curveDepositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_DEPOSIT,  CURVE_POOL);
+        curveSwapKey     = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_SWAP,     CURVE_POOL);
+        curveWithdrawKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_CURVE_WITHDRAW, CURVE_POOL);
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(curveDepositKey,  2_000_000e18, uint256(2_000_000e18) / 1 days);

--- a/test/grove-mainnet-fork/Ethena.t.sol
+++ b/test/grove-mainnet-fork/Ethena.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.0;
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 interface IEthenaMinterLike {
@@ -98,7 +100,7 @@ contract MainnetControllerPrepareUSDeMintFailureTests is EthenaTestBase {
 
     function test_prepareUSDeMint_zeroMaxAmount() external {
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDE_MINT(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDE_MINT, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -109,7 +111,7 @@ contract MainnetControllerPrepareUSDeMintFailureTests is EthenaTestBase {
     function test_prepareUSDeMint_rateLimitBoundary() external {
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(
-            mainnetController.LIMIT_USDE_MINT(),
+            RateLimitKeysLib.LIMIT_USDE_MINT,
             100e6,
             uint256(100e6) / 1 hours
         );
@@ -132,7 +134,7 @@ contract MainnetControllerPrepareUSDeMintSuccessTests is EthenaTestBase {
     function setUp() public override {
         super.setUp();
 
-        key = mainnetController.LIMIT_USDE_MINT();
+        key = RateLimitKeysLib.LIMIT_USDE_MINT;
 
         vm.prank(GROVE_PROXY);
         rateLimits.setRateLimitData(key, 5_000_000e6, uint256(1_000_000e6) / 4 hours);
@@ -180,7 +182,7 @@ contract MainnetControllerPrepareUSDeBurnFailureTests is EthenaTestBase {
 
     function test_prepareUSDeBurn_zeroMaxAmount() external {
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDE_BURN(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDE_BURN, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -191,7 +193,7 @@ contract MainnetControllerPrepareUSDeBurnFailureTests is EthenaTestBase {
     function test_prepareUSDeBurn_rateLimitBoundary() external {
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(
-            mainnetController.LIMIT_USDE_BURN(),
+            RateLimitKeysLib.LIMIT_USDE_BURN,
             100e18,
             uint256(100e18) / 1 hours
         );
@@ -214,7 +216,7 @@ contract MainnetControllerPrepareUSDeBurnSuccessTests is EthenaTestBase {
     function setUp() public override {
         super.setUp();
 
-        key = mainnetController.LIMIT_USDE_BURN();
+        key = RateLimitKeysLib.LIMIT_USDE_BURN;
 
         vm.prank(GROVE_PROXY);
         rateLimits.setRateLimitData(key, 5_000_000e18, uint256(1_000_000e18) / 4 hours);
@@ -262,7 +264,7 @@ contract MainnetControllerCooldownAssetsSUSDeFailureTests is EthenaTestBase {
 
     function test_cooldownAssetsSUSDe_zeroMaxAmount() external {
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_SUSDE_COOLDOWN(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -276,7 +278,7 @@ contract MainnetControllerCooldownAssetsSUSDeFailureTests is EthenaTestBase {
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(
-            mainnetController.LIMIT_SUSDE_COOLDOWN(),
+            RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN,
             100e18,
             uint256(100e18) / 1 hours
         );
@@ -307,7 +309,7 @@ contract MainnetControllerCooldownAssetsSUSDeSuccessTests is EthenaTestBase {
     function setUp() public override {
         super.setUp();
 
-        key = mainnetController.LIMIT_SUSDE_COOLDOWN();
+        key = RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN;
 
         vm.prank(GROVE_PROXY);
         rateLimits.setRateLimitData(key, 5_000_000e18, uint256(1_000_000e18) / 4 hours);
@@ -373,7 +375,7 @@ contract MainnetControllerCooldownSharesSUSDeFailureTests is EthenaTestBase {
         deal(address(susde), address(almProxy), 100e18);  // To get past call
 
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_SUSDE_COOLDOWN(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -386,7 +388,7 @@ contract MainnetControllerCooldownSharesSUSDeFailureTests is EthenaTestBase {
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(
-            mainnetController.LIMIT_SUSDE_COOLDOWN(),
+            RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN,
             100e18,
             uint256(100e18) / 1 hours
         );
@@ -424,7 +426,7 @@ contract MainnetControllerCooldownSharesSUSDeSuccessTests is EthenaTestBase {
     function setUp() public override {
         super.setUp();
 
-        key = mainnetController.LIMIT_SUSDE_COOLDOWN();
+        key = RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN;
 
         vm.prank(GROVE_PROXY);
         rateLimits.setRateLimitData(key, 5_000_000e18, uint256(1_000_000e18) / 4 hours);
@@ -505,7 +507,7 @@ contract MainnetControllerUnstakeSUSDeFailureTests is EthenaTestBase {
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(
-            mainnetController.LIMIT_SUSDE_COOLDOWN(),
+            RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN,
             100e18,
             uint256(100e18) / 1 hours
         );
@@ -534,7 +536,7 @@ contract MainnetControllerUnstakeSUSDeSuccessTests is EthenaTestBase {
         // Setting higher rate limit so shares can be used for cooldown
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(
-            mainnetController.LIMIT_SUSDE_COOLDOWN(),
+            RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN,
             1000e18,
             uint256(1000e18) / 1 hours
         );
@@ -579,10 +581,10 @@ contract MainnetControllerEthenaE2ETests is EthenaTestBase {
 
         vm.startPrank(GROVE_PROXY);
 
-        burnKey     = mainnetController.LIMIT_USDE_BURN();
-        cooldownKey = mainnetController.LIMIT_SUSDE_COOLDOWN();
-        depositKey  = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_4626_DEPOSIT(), address(susde));
-        mintKey     = mainnetController.LIMIT_USDE_MINT();
+        burnKey     = RateLimitKeysLib.LIMIT_USDE_BURN;
+        cooldownKey = RateLimitKeysLib.LIMIT_SUSDE_COOLDOWN;
+        depositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_DEPOSIT, address(susde));
+        mintKey     = RateLimitKeysLib.LIMIT_USDE_MINT;
 
         rateLimits.setRateLimitData(burnKey,     5_000_000e18, uint256(1_000_000e18) / 4 hours);
         rateLimits.setRateLimitData(cooldownKey, 5_000_000e18, uint256(1_000_000e18) / 4 hours);

--- a/test/grove-mainnet-fork/ForkTestBase.t.sol
+++ b/test/grove-mainnet-fork/ForkTestBase.t.sol
@@ -32,7 +32,8 @@ import { ALMProxy }          from "../../src/ALMProxy.sol";
 import { RateLimits }        from "../../src/RateLimits.sol";
 import { MainnetController } from "../../src/MainnetController.sol";
 
-import { RateLimitHelpers }  from "../../src/RateLimitHelpers.sol";
+import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
 interface IChainlogLike {
     function getAddress(bytes32) external view returns (address);
@@ -286,14 +287,14 @@ contract ForkTestBase is DssTest {
         uint256 usdcSlope     = uint256(1_000_000e6) / 4 hours;
 
         bytes32 domainKeyAvalanche = RateLimitHelpers.makeDomainKey(
-            mainnetController.LIMIT_USDC_TO_DOMAIN(),
+            RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
             CCTPForwarder.DOMAIN_ID_CIRCLE_AVALANCHE
         );
 
         // NOTE: Using minimal config for test base setup
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_MINT(),    usdsMaxAmount, usdsSlope);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_TO_USDC(), usdcMaxAmount, usdcSlope);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDC_TO_CCTP(), usdcMaxAmount, usdcSlope);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_MINT,    usdsMaxAmount, usdsSlope);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_TO_USDC, usdcMaxAmount, usdcSlope);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP, usdcMaxAmount, usdcSlope);
         rateLimits.setRateLimitData(domainKeyAvalanche,                     usdcMaxAmount, usdcSlope);
 
         vm.stopPrank();

--- a/test/grove-mainnet-fork/LayerZero.t.sol
+++ b/test/grove-mainnet-fork/LayerZero.t.sol
@@ -23,6 +23,8 @@ import {ForeignController} from "../../src/ForeignController.sol";
 import {RateLimits} from "../../src/RateLimits.sol";
 import {RateLimitHelpers} from "../../src/RateLimitHelpers.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract PlasmaChainUSDTToLayerZeroTestBase is ForkTestBase {
@@ -186,7 +188,7 @@ contract PlasmaChainUSDTToLayerZeroTestBase is ForkTestBase {
         );
 
         destinationRateLimitKey =
-            keccak256(abi.encode(foreignController.LIMIT_LAYERZERO_TRANSFER(), usdt0OftPlasma, sourceEndpointId));
+            keccak256(abi.encode(RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER, usdt0OftPlasma, sourceEndpointId));
 
         uint256 usdt0PlasmaMaxAmount = 5_000_000e6;
         uint256 usdt0PlasmaSlope     = uint256(1_000_000e6) / 4 hours;
@@ -208,7 +210,7 @@ contract PlasmaChainUSDTToLayerZeroTestBase is ForkTestBase {
 
         vm.startPrank(Ethereum.GROVE_PROXY);
         sourceRateLimitKey =
-            keccak256(abi.encode(mainnetController.LIMIT_LAYERZERO_TRANSFER(), usdtOft, destinationEndpointId));
+            keccak256(abi.encode(RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER, usdtOft, destinationEndpointId));
         uint256 usdtMaxAmount = 5_000_000e6;
         uint256 usdtSlope     = uint256(1_000_000e6) / 4 hours;
 

--- a/test/grove-mainnet-fork/Pendle.t.sol
+++ b/test/grove-mainnet-fork/Pendle.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.21;
 
 import { IPendleMarket, ISY, IYT } from "../../src/interfaces/PendleInterfaces.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract PendleTestBase is ForkTestBase {
@@ -18,7 +20,7 @@ contract PendleTestBase is ForkTestBase {
         super.setUp();
 
         redeemKey = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_PENDLE_PT_REDEEM(),
+            RateLimitKeysLib.LIMIT_PENDLE_PT_REDEEM,
             address(pendleMarket)
         );
 
@@ -181,7 +183,7 @@ contract MainnetControllerRedeemSuccessPendleTests is PendleTestBase {
     function test_redeemPendlePT_USDe() public {
         pendleMarket = IPendleMarket(0x6d98a2b6CDbF44939362a3E99793339Ba2016aF4);
         redeemKey = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_PENDLE_PT_REDEEM(),
+            RateLimitKeysLib.LIMIT_PENDLE_PT_REDEEM,
             address(pendleMarket)
         );
 
@@ -228,7 +230,7 @@ contract MainnetControllerRedeemSuccessPendleTests is PendleTestBase {
     function test_redeemPendlePT_stETH() public {
         pendleMarket = IPendleMarket(0xC374f7eC85F8C7DE3207a10bB1978bA104bdA3B2);
         redeemKey = RateLimitHelpers.makeAssetKey(
-            mainnetController.LIMIT_PENDLE_PT_REDEEM(),
+            RateLimitKeysLib.LIMIT_PENDLE_PT_REDEEM,
             address(pendleMarket)
         );
 

--- a/test/grove-mainnet-fork/PsmCalls.t.sol
+++ b/test/grove-mainnet-fork/PsmCalls.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.0;
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 interface IPSM is IPSMLike {
@@ -21,7 +23,7 @@ contract MainnetControllerSwapUSDSToUSDCFailureTests is ForkTestBase {
 
     function test_swapUSDSToUSDC_zeroMaxAmount() external {
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_TO_USDC(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_TO_USDC, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -86,10 +88,10 @@ contract MainnetControllerSwapUSDSToUSDCTests is ForkTestBase {
 
     function test_swapUSDSToUSDC_rateLimited() external {
         vm.startPrank(GROVE_PROXY);
-        rateLimits.setUnlimitedRateLimitData(mainnetController.LIMIT_USDS_MINT());
+        rateLimits.setUnlimitedRateLimitData(RateLimitKeysLib.LIMIT_USDS_MINT);
         vm.stopPrank();
 
-        bytes32 key = mainnetController.LIMIT_USDS_TO_USDC();
+        bytes32 key = RateLimitKeysLib.LIMIT_USDS_TO_USDC;
         vm.startPrank(relayer);
 
         mainnetController.mintUSDS(9_000_000e18);
@@ -137,7 +139,7 @@ contract MainnetControllerSwapUSDCToUSDSFailureTests is ForkTestBase {
 
     function test_swapUSDCToUSDS_zeroMaxAmount() external {
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_TO_USDC(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_TO_USDC, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -446,7 +448,7 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
     }
 
     function test_swapUSDCToUSDS_rateLimited() external {
-        bytes32 key = mainnetController.LIMIT_USDS_TO_USDC();
+        bytes32 key = RateLimitKeysLib.LIMIT_USDS_TO_USDC;
         vm.startPrank(relayer);
 
         mainnetController.mintUSDS(5_000_000e18);

--- a/test/grove-mainnet-fork/TransferAsset.t.sol
+++ b/test/grove-mainnet-fork/TransferAsset.t.sol
@@ -5,6 +5,8 @@ import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
 
 import { MockTokenReturnFalse } from "../unit/mocks/MockTokens.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract TransferAssetBaseTest is ForkTestBase {
@@ -17,7 +19,7 @@ contract TransferAssetBaseTest is ForkTestBase {
         vm.startPrank(Ethereum.GROVE_PROXY);
 
         bytes32 key = RateLimitHelpers.makeAssetDestinationKey(
-            mainnetController.LIMIT_ASSET_TRANSFER(),
+            RateLimitKeysLib.LIMIT_ASSET_TRANSFER,
             address(usdc),
             receiver
         );
@@ -66,7 +68,7 @@ contract MainnetControllerTransferAssetFailureTests is TransferAssetBaseTest {
 
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetDestinationKey(
-                mainnetController.LIMIT_ASSET_TRANSFER(),
+                RateLimitKeysLib.LIMIT_ASSET_TRANSFER,
                 address(token),
                 receiver
             ),
@@ -107,7 +109,7 @@ contract MainnetControllerTransferAssetSuccessTests is TransferAssetBaseTest {
 
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetDestinationKey(
-                mainnetController.LIMIT_ASSET_TRANSFER(),
+                RateLimitKeysLib.LIMIT_ASSET_TRANSFER,
                 address(usdt),
                 receiver
             ),

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -18,6 +18,8 @@ import { UniV3Utils } from "lib/dss-allocator/test/funnels/UniV3Utils.sol";
 import { FullMath }   from "lib/dss-allocator/src/funnels/uniV3/FullMath.sol";
 import { TickMath }   from "lib/dss-allocator/src/funnels/uniV3/TickMath.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 contract UniswapV3TestBase is ForkTestBase {
     address constant UNISWAP_V3_USDC_USDT_POOL   = 0x3416cF6C708Da44DB2624D63ea0AAef7113527C6;
     address constant UNISWAP_V3_DAI_USDC_POOL    = 0x6c6Bc977E13Df9b0de53b251522280BB72383700;
@@ -54,19 +56,19 @@ contract UniswapV3TestBase is ForkTestBase {
 
         stranger = makeAddr("stranger");
 
-        uniswapV3_UsdcUsdtPool_UsdcSwapKey            = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(),     address(usdc), UNISWAP_V3_USDC_USDT_POOL);
-        uniswapV3_UsdcUsdtPool_UsdtSwapKey            = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(),     address(usdt), UNISWAP_V3_USDC_USDT_POOL);
-        uniswapV3_UsdcUsdtPool_UsdcAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(usdc), UNISWAP_V3_USDC_USDT_POOL);
-        uniswapV3_UsdcUsdtPool_UsdtAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(usdt), UNISWAP_V3_USDC_USDT_POOL);
-        uniswapV3_UsdcUsdtPool_UsdcRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_WITHDRAW(), address(usdc), UNISWAP_V3_USDC_USDT_POOL);
-        uniswapV3_UsdcUsdtPool_UsdtRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_WITHDRAW(), address(usdt), UNISWAP_V3_USDC_USDT_POOL);
+        uniswapV3_UsdcUsdtPool_UsdcSwapKey            = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(usdc), UNISWAP_V3_USDC_USDT_POOL);
+        uniswapV3_UsdcUsdtPool_UsdtSwapKey            = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(usdt), UNISWAP_V3_USDC_USDT_POOL);
+        uniswapV3_UsdcUsdtPool_UsdcAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(usdc), UNISWAP_V3_USDC_USDT_POOL);
+        uniswapV3_UsdcUsdtPool_UsdtAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(usdt), UNISWAP_V3_USDC_USDT_POOL);
+        uniswapV3_UsdcUsdtPool_UsdcRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(usdc), UNISWAP_V3_USDC_USDT_POOL);
+        uniswapV3_UsdcUsdtPool_UsdtRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(usdt), UNISWAP_V3_USDC_USDT_POOL);
 
-        uniswapV3_DaiUsdcPool_DaiSwapKey             = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(),     address(dai),  UNISWAP_V3_DAI_USDC_POOL);
-        uniswapV3_DaiUsdcPool_UsdcSwapKey            = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(),     address(usdc), UNISWAP_V3_DAI_USDC_POOL);
-        uniswapV3_DaiUsdcPool_DaiAddLiquidityKey     = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(dai),  UNISWAP_V3_DAI_USDC_POOL);
-        uniswapV3_DaiUsdcPool_UsdcAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_DEPOSIT(),  address(usdc), UNISWAP_V3_DAI_USDC_POOL);
-        uniswapV3_DaiUsdcPool_DaiRemoveLiquidityKey  = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_WITHDRAW(), address(dai),  UNISWAP_V3_DAI_USDC_POOL);
-        uniswapV3_DaiUsdcPool_UsdcRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_WITHDRAW(), address(usdc), UNISWAP_V3_DAI_USDC_POOL);
+        uniswapV3_DaiUsdcPool_DaiSwapKey             = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(dai),  UNISWAP_V3_DAI_USDC_POOL);
+        uniswapV3_DaiUsdcPool_UsdcSwapKey            = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,     address(usdc), UNISWAP_V3_DAI_USDC_POOL);
+        uniswapV3_DaiUsdcPool_DaiAddLiquidityKey     = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(dai),  UNISWAP_V3_DAI_USDC_POOL);
+        uniswapV3_DaiUsdcPool_UsdcAddLiquidityKey    = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_DEPOSIT,  address(usdc), UNISWAP_V3_DAI_USDC_POOL);
+        uniswapV3_DaiUsdcPool_DaiRemoveLiquidityKey  = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(dai),  UNISWAP_V3_DAI_USDC_POOL);
+        uniswapV3_DaiUsdcPool_UsdcRemoveLiquidityKey = RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_WITHDRAW, address(usdc), UNISWAP_V3_DAI_USDC_POOL);
 
         vm.startPrank(GROVE_PROXY);
         rateLimits.setRateLimitData(uniswapV3_UsdcUsdtPool_UsdcSwapKey, 1_000_000e6,  uint256(1_000_000e6)  / 1 days);
@@ -108,7 +110,7 @@ contract UniswapV3TestBase is ForkTestBase {
 
 
     function _getSwapKey(address tokenIn) internal view returns (bytes32) {
-        return RateLimitHelpers.makeAssetDestinationKey(mainnetController.LIMIT_UNISWAP_V3_SWAP(), tokenIn, _getPool());
+        return RateLimitHelpers.makeAssetDestinationKey(RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP, tokenIn, _getPool());
     }
 
     function _label() internal {
@@ -1860,7 +1862,7 @@ contract MainnetControllerSwapSandwichAttackTest is UniswapV3TestBase {
     function _getBlock() internal pure override returns (uint256) {
         return 22181045; // Apr 02, 2025
     }
-    
+
     function test_uniswapV3_sandwichRisk_withoutTWAP() public {
         address pool                    = _getPool();
         IUniswapV3PoolLike poolContract = IUniswapV3PoolLike(pool);
@@ -1871,7 +1873,7 @@ contract MainnetControllerSwapSandwichAttackTest is UniswapV3TestBase {
 
         // Configure rate limits and Uniswap params for this pool.
         bytes32 swapKey = RateLimitHelpers.makeAssetDestinationKey(
-            mainnetController.LIMIT_UNISWAP_V3_SWAP(),
+            RateLimitKeysLib.LIMIT_UNISWAP_V3_SWAP,
             address(usdc),
             pool
         );

--- a/test/grove-mainnet-fork/VaultCalls.t.sol
+++ b/test/grove-mainnet-fork/VaultCalls.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract MainnetControllerMintUSDSFailureTests is ForkTestBase {
@@ -16,7 +18,7 @@ contract MainnetControllerMintUSDSFailureTests is ForkTestBase {
 
     function test_mintUSDS_zeroMaxAmount() external {
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_MINT(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_MINT, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -67,7 +69,7 @@ contract MainnetControllerMintUSDSSuccessTests is ForkTestBase {
     }
 
     function test_mintUSDS_rateLimited() external {
-        bytes32 key = mainnetController.LIMIT_USDS_MINT();
+        bytes32 key = RateLimitKeysLib.LIMIT_USDS_MINT;
         vm.startPrank(relayer);
 
         assertEq(rateLimits.getCurrentRateLimit(key), 5_000_000e18);
@@ -109,7 +111,7 @@ contract MainnetControllerBurnUSDSFailureTests is ForkTestBase {
 
     function test_burnUSDS_zeroMaxAmount() external {
         vm.startPrank(Ethereum.GROVE_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_MINT(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_MINT, 0, 0);
         vm.stopPrank();
 
         vm.prank(relayer);
@@ -155,7 +157,7 @@ contract MainnetControllerBurnUSDSSuccessTests is ForkTestBase {
     }
 
     function test_burnUSDS_rateLimited() external {
-        bytes32 key = mainnetController.LIMIT_USDS_MINT();
+        bytes32 key = RateLimitKeysLib.LIMIT_USDS_MINT;
         vm.startPrank(relayer);
 
         assertEq(rateLimits.getCurrentRateLimit(key), 5_000_000e18);

--- a/test/spark-base-fork/Aave.t.sol
+++ b/test/spark-base-fork/Aave.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0;
 import { IAToken } from "aave-v3-origin/src/core/contracts/interfaces/IAToken.sol";
 
 import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
 import "./ForkTestBase.t.sol";
 
@@ -24,7 +25,7 @@ contract AaveV3BaseMarketTestBase is ForkTestBase {
         // NOTE: Hit SUPPLY_CAP_EXCEEDED when using 25m
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_AAVE_DEPOSIT(),
+                RateLimitKeysLib.LIMIT_AAVE_DEPOSIT,
                 ATOKEN_USDC
             ),
             1_000_000e6,
@@ -32,7 +33,7 @@ contract AaveV3BaseMarketTestBase is ForkTestBase {
         );
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_AAVE_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
                 ATOKEN_USDC
             ),
             1_000_000e6,
@@ -141,7 +142,7 @@ contract AaveV3BaseMarketWithdrawFailureTests is AaveV3BaseMarketTestBase {
         vm.startPrank(Base.SPARK_EXECUTOR);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_AAVE_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
                 ATOKEN_USDC
             ),
             0,
@@ -180,7 +181,7 @@ contract AaveV3BaseMarketWithdrawSuccessTests is AaveV3BaseMarketTestBase {
 
     function test_withdrawAave_usdc() public {
         bytes32 key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_AAVE_WITHDRAW(),
+            RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
             ATOKEN_USDC
         );
 
@@ -227,7 +228,7 @@ contract AaveV3BaseMarketWithdrawSuccessTests is AaveV3BaseMarketTestBase {
 
     function test_withdrawAave_usdc_unlimitedRateLimit() public {
         bytes32 key = RateLimitHelpers.makeAssetKey(
-            foreignController.LIMIT_AAVE_WITHDRAW(),
+            RateLimitKeysLib.LIMIT_AAVE_WITHDRAW,
             ATOKEN_USDC
         );
         vm.prank(Base.SPARK_EXECUTOR);

--- a/test/spark-base-fork/ForkTestBase.t.sol
+++ b/test/spark-base-fork/ForkTestBase.t.sol
@@ -26,6 +26,7 @@ import { ForeignController } from "../../src/ForeignController.sol";
 import { RateLimits }        from "../../src/RateLimits.sol";
 
 import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
 contract ForkTestBase is Test {
 
@@ -170,11 +171,11 @@ contract ForkTestBase is Test {
         uint256 usdsMaxAmount = 5_000_000e18;
         uint256 usdsSlope     = uint256(1_000_000e18) / 4 hours;
 
-        bytes32 depositKey  = foreignController.LIMIT_PSM_DEPOSIT();
-        bytes32 withdrawKey = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 depositKey  = RateLimitKeysLib.LIMIT_PSM_DEPOSIT;
+        bytes32 withdrawKey = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
 
         bytes32 domainKeyEthereum = RateLimitHelpers.makeDomainKey(
-            foreignController.LIMIT_USDC_TO_DOMAIN(),
+            RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
             CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM
         );
 
@@ -183,7 +184,7 @@ contract ForkTestBase is Test {
         rateLimits.setRateLimitData(RateLimitHelpers.makeAssetKey(withdrawKey, address(usdcBase)),  usdcMaxAmount, usdcSlope);
         rateLimits.setRateLimitData(RateLimitHelpers.makeAssetKey(depositKey,  address(usdsBase)),  usdsMaxAmount, usdsSlope);
         rateLimits.setRateLimitData(RateLimitHelpers.makeAssetKey(depositKey,  address(susdsBase)), usdsMaxAmount, usdsSlope);
-        rateLimits.setRateLimitData(foreignController.LIMIT_USDC_TO_CCTP(),                         usdcMaxAmount, usdcSlope);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP,                         usdcMaxAmount, usdcSlope);
         rateLimits.setRateLimitData(domainKeyEthereum,                                              usdcMaxAmount, usdcSlope);
 
         rateLimits.setUnlimitedRateLimitData(RateLimitHelpers.makeAssetKey(withdrawKey, address(usdsBase)));

--- a/test/spark-base-fork/Morpho.t.sol
+++ b/test/spark-base-fork/Morpho.t.sol
@@ -8,6 +8,7 @@ import { MarketParamsLib }       from "morpho-blue/src/libraries/MarketParamsLib
 import { IMorpho, MarketParams } from "morpho-blue/src/interfaces/IMorpho.sol";
 
 import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
 import "./ForkTestBase.t.sol";
 
@@ -69,7 +70,7 @@ contract MorphoBaseTest is ForkTestBase {
 
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_4626_DEPOSIT(),
+                RateLimitKeysLib.LIMIT_4626_DEPOSIT,
                 MORPHO_VAULT_USDS
             ),
             25_000_000e18,
@@ -77,7 +78,7 @@ contract MorphoBaseTest is ForkTestBase {
         );
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_4626_DEPOSIT(),
+                RateLimitKeysLib.LIMIT_4626_DEPOSIT,
                 MORPHO_VAULT_USDC
             ),
             25_000_000e6,
@@ -85,7 +86,7 @@ contract MorphoBaseTest is ForkTestBase {
         );
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_4626_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_4626_WITHDRAW,
                 MORPHO_VAULT_USDS
             ),
             10_000_000e18,
@@ -93,7 +94,7 @@ contract MorphoBaseTest is ForkTestBase {
         );
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_4626_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_4626_WITHDRAW,
                 MORPHO_VAULT_USDC
             ),
             10_000_000e6,
@@ -309,7 +310,7 @@ contract MorphoRedeemFailureTests is MorphoBaseTest {
         vm.startPrank(Base.SPARK_EXECUTOR);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeAssetKey(
-                foreignController.LIMIT_4626_WITHDRAW(),
+                RateLimitKeysLib.LIMIT_4626_WITHDRAW,
                 MORPHO_VAULT_USDS
             ),
             0,

--- a/test/spark-base-fork/PsmCalls.t.sol
+++ b/test/spark-base-fork/PsmCalls.t.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.0;
 
 import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract ForeignControllerPSMSuccessTestBase is ForkTestBase {
@@ -92,7 +94,7 @@ contract ForeignControllerDepositPSMFailureTests is ForkTestBase {
 contract ForeignControllerDepositPSMTests is ForeignControllerPSMSuccessTestBase {
 
     function test_depositPSM_depositUsds() external {
-        bytes32 key = foreignController.LIMIT_PSM_DEPOSIT();
+        bytes32 key = RateLimitKeysLib.LIMIT_PSM_DEPOSIT;
 
         deal(address(usdsBase), address(almProxy), 100e18);
 
@@ -125,7 +127,7 @@ contract ForeignControllerDepositPSMTests is ForeignControllerPSMSuccessTestBase
     }
 
     function test_depositPSM_depositUsdc() external {
-        bytes32 key = foreignController.LIMIT_PSM_DEPOSIT();
+        bytes32 key = RateLimitKeysLib.LIMIT_PSM_DEPOSIT;
 
         deal(address(usdcBase), address(almProxy), 100e6);
 
@@ -158,7 +160,7 @@ contract ForeignControllerDepositPSMTests is ForeignControllerPSMSuccessTestBase
     }
 
     function test_depositPSM_depositSUsds() external {
-        bytes32 key = foreignController.LIMIT_PSM_DEPOSIT();
+        bytes32 key = RateLimitKeysLib.LIMIT_PSM_DEPOSIT;
 
         deal(address(susdsBase), address(almProxy), 100e18);
 
@@ -204,7 +206,7 @@ contract ForeignControllerWithdrawPSMFailureTests is ForkTestBase {
     }
 
     function test_withdrawPSM_usdcZeroMaxAmount() external {
-        bytes32 withdrawKey      = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 withdrawKey      = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
         bytes32 withdrawAssetKey = RateLimitHelpers.makeAssetKey(withdrawKey, address(usdcBase));
 
         vm.prank(SPARK_EXECUTOR);
@@ -216,7 +218,7 @@ contract ForeignControllerWithdrawPSMFailureTests is ForkTestBase {
     }
 
     function test_withdrawPSM_usdsZeroMaxAmount() external {
-        bytes32 withdrawKey      = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 withdrawKey      = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
         bytes32 withdrawAssetKey = RateLimitHelpers.makeAssetKey(withdrawKey, address(usdsBase));
 
         vm.prank(SPARK_EXECUTOR);
@@ -228,7 +230,7 @@ contract ForeignControllerWithdrawPSMFailureTests is ForkTestBase {
     }
 
     function test_withdrawPSM_susdsZeroMaxAmount() external {
-        bytes32 withdrawKey      = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 withdrawKey      = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
         bytes32 withdrawAssetKey = RateLimitHelpers.makeAssetKey(withdrawKey, address(susdsBase));
 
         vm.prank(SPARK_EXECUTOR);
@@ -240,7 +242,7 @@ contract ForeignControllerWithdrawPSMFailureTests is ForkTestBase {
     }
 
     function test_withdrawPSM_usdcRateLimitedBoundary() external {
-        bytes32 withdrawKey      = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 withdrawKey      = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
         bytes32 withdrawAssetKey = RateLimitHelpers.makeAssetKey(withdrawKey, address(usdcBase));
 
         vm.prank(SPARK_EXECUTOR);
@@ -258,7 +260,7 @@ contract ForeignControllerWithdrawPSMFailureTests is ForkTestBase {
     }
 
     function test_withdrawPSM_usdsRateLimitedBoundary() external {
-        bytes32 withdrawKey      = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 withdrawKey      = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
         bytes32 withdrawAssetKey = RateLimitHelpers.makeAssetKey(withdrawKey, address(usdsBase));
 
         vm.prank(SPARK_EXECUTOR);
@@ -276,7 +278,7 @@ contract ForeignControllerWithdrawPSMFailureTests is ForkTestBase {
     }
 
     function test_withdrawPSM_susdsRateLimitedBoundary() external {
-        bytes32 withdrawKey      = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 withdrawKey      = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
         bytes32 withdrawAssetKey = RateLimitHelpers.makeAssetKey(withdrawKey, address(susdsBase));
 
         vm.prank(SPARK_EXECUTOR);
@@ -301,7 +303,7 @@ contract ForeignControllerWithdrawPSMFailureTests is ForkTestBase {
 contract ForeignControllerWithdrawPSMTests is ForeignControllerPSMSuccessTestBase {
 
     function test_withdrawPSM_withdrawUsds() external {
-        bytes32 key = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 key = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
 
         deal(address(usdsBase), address(almProxy), 100e18);
         vm.prank(relayer);
@@ -336,7 +338,7 @@ contract ForeignControllerWithdrawPSMTests is ForeignControllerPSMSuccessTestBas
     }
 
     function test_withdrawPSM_withdrawUsdc() external {
-        bytes32 key = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 key = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
 
         deal(address(usdcBase), address(almProxy), 100e6);
         vm.prank(relayer);
@@ -371,7 +373,7 @@ contract ForeignControllerWithdrawPSMTests is ForeignControllerPSMSuccessTestBas
     }
 
     function test_withdrawPSM_withdrawSUsds() external {
-        bytes32 key = foreignController.LIMIT_PSM_WITHDRAW();
+        bytes32 key = RateLimitKeysLib.LIMIT_PSM_WITHDRAW;
 
         deal(address(susdsBase), address(almProxy), 100e18);
         vm.prank(relayer);

--- a/test/spark-mainnet-fork/CCTPCalls.t.sol
+++ b/test/spark-mainnet-fork/CCTPCalls.t.sol
@@ -24,6 +24,8 @@ import { ForeignController } from "../../src/ForeignController.sol";
 import { RateLimits }        from "../../src/RateLimits.sol";
 import { RateLimitHelpers }  from "../../src/RateLimitHelpers.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract MainnetControllerTransferUSDCToCCTPFailureTests is ForkTestBase {
@@ -41,7 +43,7 @@ contract MainnetControllerTransferUSDCToCCTPFailureTests is ForkTestBase {
         vm.startPrank(SPARK_PROXY);
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                mainnetController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_BASE
             ),
             0,
@@ -56,7 +58,7 @@ contract MainnetControllerTransferUSDCToCCTPFailureTests is ForkTestBase {
 
     function test_tranferUSDCToCCTP_zeroMaxAmountCCTP() external {
         vm.startPrank(SPARK_PROXY);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDC_TO_CCTP(), 0, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP, 0, 0);
         vm.stopPrank();
 
         vm.expectRevert("RateLimits/zero-maxAmount");
@@ -70,13 +72,13 @@ contract MainnetControllerTransferUSDCToCCTPFailureTests is ForkTestBase {
         // Set this so second modifier will be passed in success case
         rateLimits.setUnlimitedRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                mainnetController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_BASE
             )
         );
 
         // Rate limit will be constant 10m (higher than setup)
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDC_TO_CCTP(), 10_000_000e6, 0);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP, 10_000_000e6, 0);
 
         // Set this for success case
         mainnetController.setMintRecipient(
@@ -99,12 +101,12 @@ contract MainnetControllerTransferUSDCToCCTPFailureTests is ForkTestBase {
         vm.startPrank(SPARK_PROXY);
 
         // Set this so first modifier will be passed in success case
-        rateLimits.setUnlimitedRateLimitData(mainnetController.LIMIT_USDC_TO_CCTP());
+        rateLimits.setUnlimitedRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP);
 
         // Rate limit will be constant 10m (higher than setup)
         rateLimits.setRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                mainnetController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_BASE
             ),
             10_000_000e6,
@@ -134,12 +136,12 @@ contract MainnetControllerTransferUSDCToCCTPFailureTests is ForkTestBase {
 
         rateLimits.setUnlimitedRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                mainnetController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_ARBITRUM_ONE
             )
         );
 
-        rateLimits.setUnlimitedRateLimitData(mainnetController.LIMIT_USDC_TO_CCTP());
+        rateLimits.setUnlimitedRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP);
 
         vm.stopPrank();
 
@@ -279,11 +281,11 @@ contract BaseChainUSDCToCCTPTestBase is ForkTestBase {
         uint256 usdcSlope     = uint256(1_000_000e6) / 4 hours;
 
         bytes32 domainKeyEthereum = RateLimitHelpers.makeDomainKey(
-            foreignController.LIMIT_USDC_TO_DOMAIN(),
+            RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
             CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM
         );
 
-        foreignRateLimits.setRateLimitData(foreignController.LIMIT_USDC_TO_CCTP(), usdcMaxAmount, usdcSlope);
+        foreignRateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP, usdcMaxAmount, usdcSlope);
         foreignRateLimits.setRateLimitData(domainKeyEthereum,                      usdcMaxAmount, usdcSlope);
 
         vm.stopPrank();
@@ -325,7 +327,7 @@ contract ForeignControllerTransferUSDCToCCTPFailureTests is BaseChainUSDCToCCTPT
         vm.startPrank(SPARK_EXECUTOR);
         foreignRateLimits.setRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                foreignController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM
             ),
             0,
@@ -340,7 +342,7 @@ contract ForeignControllerTransferUSDCToCCTPFailureTests is BaseChainUSDCToCCTPT
 
     function test_tranferUSDCToCCTP_zeroMaxAmountCCTP() external {
         vm.startPrank(SPARK_EXECUTOR);
-        foreignRateLimits.setRateLimitData(foreignController.LIMIT_USDC_TO_CCTP(), 0, 0);
+        foreignRateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP, 0, 0);
         vm.stopPrank();
 
         vm.expectRevert("RateLimits/zero-maxAmount");
@@ -354,13 +356,13 @@ contract ForeignControllerTransferUSDCToCCTPFailureTests is BaseChainUSDCToCCTPT
         // Set this so second modifier will be passed in success case
         foreignRateLimits.setUnlimitedRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                foreignController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM
             )
         );
 
         // Rate limit will be constant 10m (higher than setup)
-        foreignRateLimits.setRateLimitData(foreignController.LIMIT_USDC_TO_CCTP(), 10_000_000e6, 0);
+        foreignRateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP, 10_000_000e6, 0);
 
         // Set this for success case
         foreignController.setMintRecipient(
@@ -383,12 +385,12 @@ contract ForeignControllerTransferUSDCToCCTPFailureTests is BaseChainUSDCToCCTPT
         vm.startPrank(SPARK_EXECUTOR);
 
         // Set this so first modifier will be passed in success case
-        foreignRateLimits.setUnlimitedRateLimitData(foreignController.LIMIT_USDC_TO_CCTP());
+        foreignRateLimits.setUnlimitedRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP);
 
         // Rate limit will be constant 10m (higher than setup)
         foreignRateLimits.setRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                foreignController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM
             ),
             10_000_000e6,
@@ -418,12 +420,12 @@ contract ForeignControllerTransferUSDCToCCTPFailureTests is BaseChainUSDCToCCTPT
 
         foreignRateLimits.setUnlimitedRateLimitData(
             RateLimitHelpers.makeDomainKey(
-                foreignController.LIMIT_USDC_TO_DOMAIN(),
+                RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
                 CCTPForwarder.DOMAIN_ID_CIRCLE_ARBITRUM_ONE
             )
         );
 
-        foreignRateLimits.setUnlimitedRateLimitData(foreignController.LIMIT_USDC_TO_CCTP());
+        foreignRateLimits.setUnlimitedRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP);
 
         vm.stopPrank();
 
@@ -528,7 +530,7 @@ contract USDCToCCTPIntegrationTests is BaseChainUSDCToCCTPTestBase {
     }
 
     function test_transferUSDCToCCTP_sourceToDestination_rateLimited() external {
-        bytes32 key = mainnetController.LIMIT_USDC_TO_CCTP();
+        bytes32 key = RateLimitKeysLib.LIMIT_USDC_TO_CCTP;
         deal(address(usdc), address(almProxy), 9_000_000e6);
 
         vm.startPrank(relayer);
@@ -638,7 +640,7 @@ contract USDCToCCTPIntegrationTests is BaseChainUSDCToCCTPTestBase {
     function test_transferUSDCToCCTP_destinationToSource_rateLimited() external {
         destination.selectFork();
 
-        bytes32 key = foreignController.LIMIT_USDC_TO_CCTP();
+        bytes32 key = RateLimitKeysLib.LIMIT_USDC_TO_CCTP;
         deal(address(usdcBase), address(foreignAlmProxy), 9_000_000e6);
 
         vm.startPrank(relayer);

--- a/test/spark-mainnet-fork/ERC4626DonationAttack.t.sol
+++ b/test/spark-mainnet-fork/ERC4626DonationAttack.t.sol
@@ -6,6 +6,8 @@ import { IMetaMorpho, Id } from "metamorpho/interfaces/IMetaMorpho.sol";
 import { MarketParamsLib }               from "morpho-blue/src/libraries/MarketParamsLib.sol";
 import { IMorpho, MarketParams, Market } from "morpho-blue/src/interfaces/IMorpho.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 import "./ForkTestBase.t.sol";
 
 contract ERC4626DonationAttackTestBase is ForkTestBase {
@@ -36,8 +38,8 @@ contract ERC4626DonationAttackTestBase is ForkTestBase {
 
         morpho = morphoVault.MORPHO();
 
-        bytes32 depositKey  = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_4626_DEPOSIT(),  address(morphoVault));
-        bytes32 withdrawKey = RateLimitHelpers.makeAssetKey(mainnetController.LIMIT_4626_WITHDRAW(), address(morphoVault));
+        bytes32 depositKey  = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_DEPOSIT,  address(morphoVault));
+        bytes32 withdrawKey = RateLimitHelpers.makeAssetKey(RateLimitKeysLib.LIMIT_4626_WITHDRAW, address(morphoVault));
 
         // Basic validation
         assertEq(keccak256(abi.encode(morphoVault.symbol())), keccak256(abi.encode("sparkUSDS")));

--- a/test/spark-mainnet-fork/ForkTestBase.t.sol
+++ b/test/spark-mainnet-fork/ForkTestBase.t.sol
@@ -33,7 +33,8 @@ import { ALMProxy }          from "../../src/ALMProxy.sol";
 import { RateLimits }        from "../../src/RateLimits.sol";
 import { MainnetController } from "../../src/MainnetController.sol";
 
-import { RateLimitHelpers }  from "../../src/RateLimitHelpers.sol";
+import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
 
 interface IChainlogLike {
     function getAddress(bytes32) external view returns (address);
@@ -284,14 +285,14 @@ contract ForkTestBase is DssTest {
         uint256 usdcSlope     = uint256(1_000_000e6) / 4 hours;
 
         bytes32 domainKeyBase = RateLimitHelpers.makeDomainKey(
-            mainnetController.LIMIT_USDC_TO_DOMAIN(),
+            RateLimitKeysLib.LIMIT_USDC_TO_DOMAIN,
             CCTPForwarder.DOMAIN_ID_CIRCLE_BASE
         );
 
         // NOTE: Using minimal config for test base setup
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_MINT(),    usdsMaxAmount, usdsSlope);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_TO_USDC(), usdcMaxAmount, usdcSlope);
-        rateLimits.setRateLimitData(mainnetController.LIMIT_USDC_TO_CCTP(), usdcMaxAmount, usdcSlope);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_MINT,    usdsMaxAmount, usdsSlope);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDS_TO_USDC, usdcMaxAmount, usdcSlope);
+        rateLimits.setRateLimitData(RateLimitKeysLib.LIMIT_USDC_TO_CCTP, usdcMaxAmount, usdcSlope);
         rateLimits.setRateLimitData(domainKeyBase,                          usdcMaxAmount, usdcSlope);
 
         vm.stopPrank();

--- a/test/spark-mainnet-fork/LayerZero.t.sol
+++ b/test/spark-mainnet-fork/LayerZero.t.sol
@@ -28,6 +28,8 @@ import "src/interfaces/ILayerZero.sol";
 
 import { CCTPv2Forwarder as CCTPForwarder } from "xchain-helpers/forwarders/CCTPv2Forwarder.sol";
 
+import { RateLimitKeysLib } from "../../src/libraries/RateLimitKeysLib.sol";
+
 contract MainnetControllerLayerZeroTestBase is ForkTestBase {
 
     uint32 constant destinationEndpointId = 30110;  // Arbitrum EID
@@ -57,7 +59,7 @@ contract MainnetControllerTransferLayerZeroFailureTests is MainnetControllerLaye
         vm.startPrank(SPARK_PROXY);
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                mainnetController.LIMIT_LAYERZERO_TRANSFER(),
+                RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER,
                 USDT_OFT,
                 destinationEndpointId
             )),
@@ -78,7 +80,7 @@ contract MainnetControllerTransferLayerZeroFailureTests is MainnetControllerLaye
 
         rateLimits.setRateLimitData(
             keccak256(abi.encode(
-                mainnetController.LIMIT_LAYERZERO_TRANSFER(),
+                RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER,
                 USDT_OFT,
                 destinationEndpointId
             )),
@@ -141,7 +143,7 @@ contract MainnetControllerTransferLayerZeroSuccessTests is MainnetControllerLaye
         vm.startPrank(SPARK_PROXY);
 
         bytes32 key = keccak256(abi.encode(
-            mainnetController.LIMIT_LAYERZERO_TRANSFER(),
+            RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER,
             USDT_OFT,
             destinationEndpointId
         ));
@@ -358,7 +360,7 @@ contract ForeignControllerTransferLayerZeroFailureTests is ArbitrumChainLayerZer
         vm.startPrank(SPARK_EXECUTOR);
         foreignRateLimits.setRateLimitData(
             keccak256(abi.encode(
-                foreignController.LIMIT_LAYERZERO_TRANSFER(),
+                RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER,
                 USDT_OFT,
                 destinationEndpointId
             )),
@@ -379,7 +381,7 @@ contract ForeignControllerTransferLayerZeroFailureTests is ArbitrumChainLayerZer
 
         foreignRateLimits.setRateLimitData(
             keccak256(abi.encode(
-                foreignController.LIMIT_LAYERZERO_TRANSFER(),
+                RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER,
                 USDT_OFT,
                 destinationEndpointId
             )),
@@ -452,7 +454,7 @@ contract ForeignControllerTransferLayerZeroSuccessTests is ArbitrumChainLayerZer
         vm.startPrank(SPARK_EXECUTOR);
 
         bytes32 key = keccak256(abi.encode(
-            foreignController.LIMIT_LAYERZERO_TRANSFER(),
+            RateLimitKeysLib.LIMIT_LAYERZERO_TRANSFER,
             USDT_OFT,
             destinationEndpointId
         ));


### PR DESCRIPTION
Rather small improvement size wise, but posting nevertheless

Before:
| Contract                                                                         | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| --- | --- | --- | --- | --- |
| ForeignController                                                       | 21,932           | 23,343            | 2,644              | 25,809              |
| MainnetController                                                                | 22,856           | 24,981            | 1,720              | 24,171              |

After:

| Contract                                                                         | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| --- | --- | --- | --- | --- |
| ForeignController                                                                | 22,035           | 22,726            | 2,541              | 26,426              |
| MainnetController                                                                | 22,995           | 24,295            | 1,581              | 24,857              |