### PR TITLE
refactor: use Centrifuge library in FC

### DIFF
--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -550,62 +550,48 @@ contract ForeignController is AccessControl {
 
     // NOTE: These cancelation methods are compatible with ERC-7887
 
-    function cancelCentrifugeDepositRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token))
-    {
-        // NOTE: While the cancelation is pending, no new deposit request can be submitted
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).cancelDepositRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy))
-            )
-        );
+    function cancelCentrifugeDepositRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.cancelCentrifugeDepositRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_DEPOSIT,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
-    function claimCentrifugeCancelDepositRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token))
-    {
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).claimCancelDepositRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy), address(proxy))
-            )
-        );
+    function claimCentrifugeCancelDepositRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.claimCentrifugeCancelDepositRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_DEPOSIT,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
-    function cancelCentrifugeRedeemRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token))
-    {
-        // NOTE: While the cancelation is pending, no new redeem request can be submitted
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).cancelRedeemRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy))
-            )
-        );
+    function cancelCentrifugeRedeemRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.cancelCentrifugeRedeemRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_REDEEM,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
-    function claimCentrifugeCancelRedeemRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token))
-    {
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).claimCancelRedeemRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy), address(proxy))
-            )
-        );
+    function claimCentrifugeCancelRedeemRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.claimCentrifugeCancelRedeemRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_REDEEM,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
     function transferSharesCentrifuge(

--- a/test/grove-avalanche-fork/Centrifuge.t.sol
+++ b/test/grove-avalanche-fork/Centrifuge.t.sol
@@ -343,7 +343,7 @@ contract ForeignControllerCancelCentrifugeDepositFailureTests is CentrifugeTestB
 
     function test_cancelCentrifugeDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.cancelCentrifugeDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -399,7 +399,7 @@ contract ForeignControllerClaimCentrifugeCancelDepositFailureTests is Centrifuge
 
     function test_claimCentrifugeCancelDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.claimCentrifugeCancelDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -795,7 +795,7 @@ contract ForeignControllerCancelCentrifugeRedeemRequestFailureTests is Centrifug
 
     function test_cancelCentrifugeRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.cancelCentrifugeRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -855,7 +855,7 @@ contract ForeignControllerClaimCentrifugeCancelRedeemRequestFailureTests is Cent
 
     function test_claimCentrifugeCancelRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.claimCentrifugeCancelRedeemRequest(makeAddr("fake-vault"));
     }
 


### PR DESCRIPTION
Before:
| Contract                                                                         | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| --- | --- | --- | --- | --- |
| ForeignController                                                                | 21,932           | 23,343            | 2,644              | 25,809              |
| MainnetController                                                                | 22,856           | 24,981            | 1,720              | 24,171              |

After:
| Contract                                                                         | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
| --- | --- | --- | --- | --- |
| ForeignController                                                                | 21,484           | 22,895            | 3,092              | 26,257              |
| MainnetController                                                                | 22,856           | 24,981            | 1,720              | 24,171              |