### PR TITLE
Controller v1.9.0 changes

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,6 +13,7 @@ evm_version = 'cancun'
 remappings = [
     '@layerzerolabs/oft-evm/=lib/devtools/packages/oft-evm/',
     'layerzerolabs/oapp-evm/=lib/devtools/packages/oapp-evm/',
+    '@layerzerolabs/oapp-evm/=lib/devtools/packages/oapp-evm/',
     '@layerzerolabs/lz-evm-protocol-v2/=lib/layerzero-v2/packages/layerzero-v2/evm/protocol',
     '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/',
     '@layerzerolabs/lz-evm-messagelib-v2/=lib/layerzero-v2/packages/layerzero-v2/evm/messagelib/',

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -18,12 +18,13 @@ import { ICCTPLike }     from "./interfaces/CCTPInterfaces.sol";
 import { IRateLimits }   from "./interfaces/IRateLimits.sol";
 import { IPendleMarket } from "./interfaces/PendleInterfaces.sol";
 
-import { CurveLib }     from "./libraries/CurveLib.sol";
-import { MerklLib }     from "./libraries/MerklLib.sol";
-import { PendleLib }    from "./libraries/PendleLib.sol";
-import { CCTPLib }      from "./libraries/CCTPLib.sol";
-import { ERC20Lib }     from "./libraries/common/ERC20Lib.sol";
-import { UniswapV3Lib } from "./libraries/UniswapV3Lib.sol";
+import { CentrifugeLib } from "./libraries/CentrifugeLib.sol";
+import { CurveLib }      from "./libraries/CurveLib.sol";
+import { MerklLib }      from "./libraries/MerklLib.sol";
+import { PendleLib }     from "./libraries/PendleLib.sol";
+import { CCTPLib }       from "./libraries/CCTPLib.sol";
+import { ERC20Lib }      from "./libraries/common/ERC20Lib.sol";
+import { UniswapV3Lib }  from "./libraries/UniswapV3Lib.sol";
 
 import { ISwapRouter, INonfungiblePositionManager }                    from "./interfaces/UniswapV3Interfaces.sol";
 import { ICentrifugeV3VaultLike, IAsyncRedeemManagerLike, ISpokeLike } from "./interfaces/CentrifugeInterfaces.sol";
@@ -615,34 +616,15 @@ contract ForeignController is AccessControl {
         external payable
     {
         _checkRole(RELAYER);
-        _rateLimited(
-            keccak256(abi.encode(LIMIT_CENTRIFUGE_TRANSFER, token, destinationCentrifugeId)),
-            amount
-        );
-
-        bytes32 recipient = centrifugeRecipients[destinationCentrifugeId];
-        require(recipient != 0, "FC/id-not-configured");
-
-        ICentrifugeV3VaultLike centrifugeVault = ICentrifugeV3VaultLike(token);
-
-        address spoke = IAsyncRedeemManagerLike(centrifugeVault.manager()).spoke();
-
-        // Initiate cross-chain transfer via the specific spoke address
-        proxy.doCallWithValue{value: msg.value}(
-            spoke,
-            abi.encodeCall(
-                ISpokeLike(spoke).crosschainTransferShares,
-                (
-                    destinationCentrifugeId,
-                    centrifugeVault.poolId(),
-                    centrifugeVault.scId(),
-                    recipient,
-                    amount,
-                    0
-                )
-            ),
-            msg.value
-        );
+        CentrifugeLib.transferSharesCentrifuge(CentrifugeLib.CentrifugeTransferParams({
+            proxy                   : proxy,
+            rateLimits              : rateLimits,
+            token                   : token,
+            amount                  : amount,
+            recipient               : centrifugeRecipients[destinationCentrifugeId],
+            destinationCentrifugeId : destinationCentrifugeId,
+            rateLimitId             : LIMIT_CENTRIFUGE_TRANSFER
+        }));
     }
 
     /**********************************************************************************************/

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -167,7 +167,7 @@ contract ForeignController is AccessControl {
     modifier rateLimitExists(bytes32 key) {
         require(
             rateLimits.getRateLimitData(key).maxAmount > 0,
-            "ForeignController/invalid-action"
+            "FC/invalid-action"
         );
         _;
     }
@@ -196,7 +196,7 @@ contract ForeignController is AccessControl {
         external
         onlyRole(DEFAULT_ADMIN_ROLE)
     {
-        require(maxSlippage <= 1e18, "ForeignController/max-slippage-out-of-bounds");
+        require(maxSlippage <= 1e18, "FC/max-slippage-oob");
         maxSlippages[pool] = maxSlippage;
         emit MaxSlippageSet(pool, maxSlippage);
     }
@@ -215,7 +215,7 @@ contract ForeignController is AccessControl {
         require(
             maxTickDelta > 0 &&
             maxTickDelta <= UniswapV3Lib.MAX_TICK_DELTA,
-            "ForeignController/max-tick-delta-out-of-bounds"
+            "FC/max-tick-delta-oob"
         );
 
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
@@ -225,7 +225,7 @@ contract ForeignController is AccessControl {
 
     function setUniswapV3AddLiquidityLowerTickBound(address pool, int24 lowerTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "ForeignController/lower-tick-out-of-bounds");
+        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "FC/lower-tick-oob");
 
         params.addLiquidityTickBounds.lower = lowerTickBound;
         emit UniswapV3PoolLowerTickUpdated(pool, lowerTickBound);
@@ -233,7 +233,7 @@ contract ForeignController is AccessControl {
 
     function setUniswapV3AddLiquidityUpperTickBound(address pool, int24 upperTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "ForeignController/upper-tick-out-of-bounds");
+        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "FC/upper-tick-oob");
 
         params.addLiquidityTickBounds.upper = upperTickBound;
         emit UniswapV3PoolUpperTickUpdated(pool, upperTickBound);
@@ -243,7 +243,7 @@ contract ForeignController is AccessControl {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
         // Required due to casting in UniswapV3OracleLibrary.consult
         // Limits twapSecondsAgo to approximately 68 years
-        require(twapSecondsAgo < uint32(type(int32).max), "ForeignController/twap-seconds-ago-out-of-bounds");
+        require(twapSecondsAgo < uint32(type(int32).max), "FC/twap-seconds-ago-oob");
         params.twapSecondsAgo = twapSecondsAgo;
         emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }
@@ -259,7 +259,7 @@ contract ForeignController is AccessControl {
     function setMaxExchangeRate(address token, uint256 shares, uint256 maxExpectedAssets) external {
         _checkRole(DEFAULT_ADMIN_ROLE);
 
-        require(token != address(0), "ForeignController/token-zero-address");
+        require(token != address(0), "FC/token-zero-address");
 
         emit MaxExchangeRateSet(
             token,
@@ -436,7 +436,7 @@ contract ForeignController is AccessControl {
 
         require(
             _getExchangeRate(shares, amount) <= maxExchangeRates[token],
-            "ForeignController/exchange-rate-too-high"
+            "FC/exchange-rate-too-high"
         );
     }
 
@@ -621,7 +621,7 @@ contract ForeignController is AccessControl {
         );
 
         bytes32 recipient = centrifugeRecipients[destinationCentrifugeId];
-        require(recipient != 0, "ForeignController/centrifuge-id-not-configured");
+        require(recipient != 0, "FC/id-not-configured");
 
         ICentrifugeV3VaultLike centrifugeVault = ICentrifugeV3VaultLike(token);
 
@@ -654,7 +654,7 @@ contract ForeignController is AccessControl {
         onlyRole(RELAYER)
         rateLimitedAsset(LIMIT_AAVE_DEPOSIT, aToken, amount)
     {
-        require(maxSlippages[aToken] != 0, "ForeignController/max-slippage-not-set");
+        require(maxSlippages[aToken] != 0, "FC/max-slippage-not-set");
 
         IERC20    underlying = IERC20(IATokenWithPool(aToken).UNDERLYING_ASSET_ADDRESS());
         IAavePool pool       = IAavePool(IATokenWithPool(aToken).POOL());
@@ -674,7 +674,7 @@ contract ForeignController is AccessControl {
 
         require(
             newATokens >= amount * maxSlippages[aToken] / 1e18,
-            "ForeignController/slippage-too-high"
+            "FC/slippage-too-high"
         );
     }
 
@@ -780,7 +780,7 @@ contract ForeignController is AccessControl {
 
     function toggleOperatorMerkl(address operator) external {
         _checkRole(RELAYER);
-        require(address(merklDistributor) != address(0), "ForeignController/merkl-distributor-not-set");
+        require(address(merklDistributor) != address(0), "FC/merkl-distributor-not-set");
 
         MerklLib.toggleOperator(MerklLib.MerklToggleOperatorParams({
             proxy        : proxy,
@@ -928,7 +928,7 @@ contract ForeignController is AccessControl {
         if (assets == 0) return 0;
 
         // Zero shares with non-zero assets is invalid (infinite exchange rate).
-        if (shares == 0) revert("ForeignController/zero-shares");
+        if (shares == 0) revert("FC/zero-shares");
 
         return (EXCHANGE_RATE_PRECISION * assets) / shares;
     }

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -550,62 +550,48 @@ contract ForeignController is AccessControl {
 
     // NOTE: These cancelation methods are compatible with ERC-7887
 
-    function cancelCentrifugeDepositRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token))
-    {
-        // NOTE: While the cancelation is pending, no new deposit request can be submitted
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).cancelDepositRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy))
-            )
-        );
+    function cancelCentrifugeDepositRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.cancelCentrifugeDepositRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_DEPOSIT,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
-    function claimCentrifugeCancelDepositRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_DEPOSIT, token))
-    {
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).claimCancelDepositRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy), address(proxy))
-            )
-        );
+    function claimCentrifugeCancelDepositRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.claimCentrifugeCancelDepositRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_DEPOSIT,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
-    function cancelCentrifugeRedeemRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token))
-    {
-        // NOTE: While the cancelation is pending, no new redeem request can be submitted
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).cancelRedeemRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy))
-            )
-        );
+    function cancelCentrifugeRedeemRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.cancelCentrifugeRedeemRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_REDEEM,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
-    function claimCentrifugeCancelRedeemRequest(address token)
-        external
-        onlyRole(RELAYER)
-        rateLimitExists(RateLimitHelpers.makeAssetKey(LIMIT_7540_REDEEM, token))
-    {
-        proxy.doCall(
-            token,
-            abi.encodeCall(
-                ICentrifugeV3VaultLike(token).claimCancelRedeemRequest,
-                (CENTRIFUGE_REQUEST_ID, address(proxy), address(proxy))
-            )
-        );
+    function claimCentrifugeCancelRedeemRequest(address token) external {
+        _checkRole(RELAYER);
+        CentrifugeLib.claimCentrifugeCancelRedeemRequest(CentrifugeLib.CentrifugeRequestParams({
+            proxy       : proxy,
+            rateLimits  : rateLimits,
+            token       : token,
+            rateLimitId : LIMIT_7540_REDEEM,
+            requestId   : CENTRIFUGE_REQUEST_ID
+        }));
     }
 
     function transferSharesCentrifuge(

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -205,7 +205,7 @@ contract MainnetController is AccessControl {
 
     function setMaxSlippage(address pool, uint256 maxSlippage) external {
         _checkRole(DEFAULT_ADMIN_ROLE);
-        require(maxSlippage <= 1e18, "MainnetController/max-slippage-out-of-bounds");
+        require(maxSlippage <= 1e18, "MC/max-slippage-oob");
         maxSlippages[pool] = maxSlippage;
         emit MaxSlippageSet(pool, maxSlippage);
     }
@@ -216,7 +216,7 @@ contract MainnetController is AccessControl {
         require(
             maxTickDelta > 0 &&
             maxTickDelta <= UniswapV3Lib.MAX_TICK_DELTA,
-            "MainnetController/max-tick-delta-out-of-bounds"
+            "MC/max-tick-delta-oob"
         );
 
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
@@ -226,7 +226,7 @@ contract MainnetController is AccessControl {
 
     function setUniswapV3AddLiquidityLowerTickBound(address pool, int24 lowerTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "MainnetController/lower-tick-out-of-bounds");
+        require(lowerTickBound >= MIN_TICK && lowerTickBound < params.addLiquidityTickBounds.upper, "MC/lower-tick-oob");
 
         params.addLiquidityTickBounds.lower = lowerTickBound;
         emit UniswapV3PoolLowerTickUpdated(pool, lowerTickBound);
@@ -234,7 +234,7 @@ contract MainnetController is AccessControl {
 
     function setUniswapV3AddLiquidityUpperTickBound(address pool, int24 upperTickBound) external onlyRole(DEFAULT_ADMIN_ROLE) {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
-        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "MainnetController/upper-tick-out-of-bounds");
+        require(upperTickBound > params.addLiquidityTickBounds.lower && upperTickBound <= MAX_TICK, "MC/upper-tick-oob");
 
         params.addLiquidityTickBounds.upper = upperTickBound;
         emit UniswapV3PoolUpperTickUpdated(pool, upperTickBound);
@@ -244,7 +244,7 @@ contract MainnetController is AccessControl {
         UniswapV3Lib.UniswapV3PoolParams storage params = uniswapV3PoolParams[pool];
         // Required due to casting in UniswapV3OracleLibrary.consult
         // Limits twapSecondsAgo to approximately 68 years
-        require(twapSecondsAgo < uint32(type(int32).max), "MainnetController/twap-seconds-ago-out-of-bounds");
+        require(twapSecondsAgo < uint32(type(int32).max), "MC/twap-seconds-ago-oob");
         params.twapSecondsAgo = twapSecondsAgo;
         emit UniswapV3PoolTwapSecondsAgoUpdated(pool, twapSecondsAgo);
     }
@@ -258,7 +258,7 @@ contract MainnetController is AccessControl {
     function setMaxExchangeRate(address token, uint256 shares, uint256 maxExpectedAssets) external {
         _checkRole(DEFAULT_ADMIN_ROLE);
 
-        require(token != address(0), "MainnetController/token-zero-address");
+        require(token != address(0), "MC/token-zero-address");
 
         emit MaxExchangeRateSet(
             token,
@@ -350,7 +350,7 @@ contract MainnetController is AccessControl {
 
         require(
             _getExchangeRate(shares, amount) <= maxExchangeRates[token],
-            "MainnetController/exchange-rate-too-high"
+            "MC/exchange-rate-too-high"
         );
     }
 
@@ -506,7 +506,7 @@ contract MainnetController is AccessControl {
         _checkRole(RELAYER);
         _rateLimitedAsset(LIMIT_AAVE_DEPOSIT, aToken, amount);
 
-        require(maxSlippages[aToken] != 0, "MainnetController/max-slippage-not-set");
+        require(maxSlippages[aToken] != 0, "MC/max-slippage-not-set");
 
         IERC20    underlying = IERC20(IATokenWithPool(aToken).UNDERLYING_ASSET_ADDRESS());
         IAavePool pool       = IAavePool(IATokenWithPool(aToken).POOL());
@@ -526,7 +526,7 @@ contract MainnetController is AccessControl {
 
         require(
             newATokens >= amount * maxSlippages[aToken] / 1e18,
-            "MainnetController/slippage-too-high"
+            "MC/slippage-too-high"
         );
     }
 
@@ -994,7 +994,7 @@ contract MainnetController is AccessControl {
     function _rateLimitExists(bytes32 key) internal view {
         require(
             rateLimits.getRateLimitData(key).maxAmount > 0,
-            "MainnetController/invalid-action"
+            "MC/invalid-action"
         );
     }
 
@@ -1035,7 +1035,7 @@ contract MainnetController is AccessControl {
         if (assets == 0) return 0;
 
         // Zero shares with non-zero assets is invalid (infinite exchange rate).
-        if (shares == 0) revert("MainnetController/zero-shares");
+        if (shares == 0) revert("MC/zero-shares");
 
         return (EXCHANGE_RATE_PRECISION * assets) / shares;
     }

--- a/src/libraries/CentrifugeLib.sol
+++ b/src/libraries/CentrifugeLib.sol
@@ -89,7 +89,7 @@ library CentrifugeLib {
             params.amount
         );
 
-        require(params.recipient != 0, "MainnetController/centrifuge-id-not-configured");
+        require(params.recipient != 0, "CentrifugeLib/id-not-configured");
 
         ICentrifugeV3VaultLike centrifugeVault = ICentrifugeV3VaultLike(params.token);
 
@@ -124,7 +124,7 @@ library CentrifugeLib {
     function _rateLimitExists(IRateLimits rateLimits, bytes32 key) internal view {
         require(
             rateLimits.getRateLimitData(key).maxAmount > 0,
-            "MainnetController/invalid-action"
+            "CentrifugeLib/invalid-action"
         );
     }
 }

--- a/src/libraries/UniswapV3Lib.sol
+++ b/src/libraries/UniswapV3Lib.sol
@@ -464,7 +464,7 @@ library UniswapV3Lib {
         ) = _fetchPositionData(params.tokenId, params.positionManager);
 
         require(positionToken0 == token0 && positionToken1 == token1 && positionFee == fee, "UniswapV3Lib/invalid-pool");
-        require(params.liquidity > 0 && params.liquidity <= positionLiquidity,              "UniswapV3Lib/liquidity-out-of-bounds");
+        require(params.liquidity > 0 && params.liquidity <= positionLiquidity,              "UniswapV3Lib/liquidity-oob");
     }
 
     function _decreaseLiquidityCall(

--- a/test/grove-avalanche-fork/Centrifuge.t.sol
+++ b/test/grove-avalanche-fork/Centrifuge.t.sol
@@ -1012,7 +1012,7 @@ contract ForeignControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
         deal(ALM_RELAYER, 1 ether);  // Gas cost for Centrifuge
 
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("FC/id-not-configured");
+        vm.expectRevert("CentrifugeLib/id-not-configured");
         foreignController.transferSharesCentrifuge{value: 0.5 ether}(
             CENTRIFUGE_VAULT,
             10_000_000e6,

--- a/test/grove-avalanche-fork/Centrifuge.t.sol
+++ b/test/grove-avalanche-fork/Centrifuge.t.sol
@@ -343,7 +343,7 @@ contract ForeignControllerCancelCentrifugeDepositFailureTests is CentrifugeTestB
 
     function test_cancelCentrifugeDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.cancelCentrifugeDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -399,7 +399,7 @@ contract ForeignControllerClaimCentrifugeCancelDepositFailureTests is Centrifuge
 
     function test_claimCentrifugeCancelDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.claimCentrifugeCancelDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -795,7 +795,7 @@ contract ForeignControllerCancelCentrifugeRedeemRequestFailureTests is Centrifug
 
     function test_cancelCentrifugeRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.cancelCentrifugeRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -855,7 +855,7 @@ contract ForeignControllerClaimCentrifugeCancelRedeemRequestFailureTests is Cent
 
     function test_claimCentrifugeCancelRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("FC/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         foreignController.claimCentrifugeCancelRedeemRequest(makeAddr("fake-vault"));
     }
 

--- a/test/grove-avalanche-fork/Centrifuge.t.sol
+++ b/test/grove-avalanche-fork/Centrifuge.t.sol
@@ -172,7 +172,7 @@ contract ForeignControllerClaimDepositERC7540FailureTests is CentrifugeTestBase 
 
     function test_claimDepositERC7540_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimDepositERC7540(makeAddr("fake-vault"));
     }
 
@@ -343,7 +343,7 @@ contract ForeignControllerCancelCentrifugeDepositFailureTests is CentrifugeTestB
 
     function test_cancelCentrifugeDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.cancelCentrifugeDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -399,7 +399,7 @@ contract ForeignControllerClaimCentrifugeCancelDepositFailureTests is Centrifuge
 
     function test_claimCentrifugeCancelDepositRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimCentrifugeCancelDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -592,7 +592,7 @@ contract ForeignControllerClaimRedeemERC7540FailureTests is CentrifugeTestBase {
 
     function test_claimRedeemERC7540_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimRedeemERC7540(makeAddr("fake-vault"));
     }
 
@@ -795,7 +795,7 @@ contract ForeignControllerCancelCentrifugeRedeemRequestFailureTests is Centrifug
 
     function test_cancelCentrifugeRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.cancelCentrifugeRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -855,7 +855,7 @@ contract ForeignControllerClaimCentrifugeCancelRedeemRequestFailureTests is Cent
 
     function test_claimCentrifugeCancelRedeemRequest_invalidVault() external {
         vm.prank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/invalid-action");
+        vm.expectRevert("FC/invalid-action");
         foreignController.claimCentrifugeCancelRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -1012,7 +1012,7 @@ contract ForeignControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
         deal(ALM_RELAYER, 1 ether);  // Gas cost for Centrifuge
 
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("ForeignController/centrifuge-id-not-configured");
+        vm.expectRevert("FC/id-not-configured");
         foreignController.transferSharesCentrifuge{value: 0.5 ether}(
             CENTRIFUGE_VAULT,
             10_000_000e6,

--- a/test/grove-base-fork/Merkl.sol
+++ b/test/grove-base-fork/Merkl.sol
@@ -29,7 +29,7 @@ contract MerklBaseTest is ForkTestBase {
 contract ForeignControllerToggleOperatorMerklFailureTests is MerklBaseTest {
 
     function test_toggleOperatorMerkl_merklDistributorNotSet() external {
-        vm.expectRevert("ForeignController/merkl-distributor-not-set");
+        vm.expectRevert("FC/merkl-distributor-not-set");
 
         vm.prank(relayer);
         foreignController.toggleOperatorMerkl(operator1);

--- a/test/grove-base-fork/UniswapV3.t.sol
+++ b/test/grove-base-fork/UniswapV3.t.sol
@@ -219,19 +219,19 @@ contract ForeignControllerConfigFailureTests is UniswapV3TestBase {
 
     function test_setUniswapV3PoolMaxTickDelta_isZero() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_isTooLarge() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), UniswapV3Lib.MAX_TICK_DELTA + 1);
     }
 
     function test_setUniswapV3AddLiquidityLowerTickBound_isTooSmall() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), MIN_UNISWAP_TICK - 1);
     }
 
@@ -240,13 +240,13 @@ contract ForeignControllerConfigFailureTests is UniswapV3TestBase {
         int24 currentUpper = tickBounds.upper;
 
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), currentUpper);
     }
 
     function test_setUniswapV3AddLiquidityUpperTickBound_isTooLarge() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), MAX_UNISWAP_TICK + 1);
     }
 }
@@ -264,13 +264,13 @@ contract ForeignControllerSwapUniswapV3FailureTests is UniswapV3TestBase {
 
     function test_setUniswapV3PoolMaxTickDelta_zeroTickDelta() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_outOfBounds() public {
         vm.prank(GROVE_EXECUTOR);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(_getPool(), UniswapV3Lib.MAX_TICK_DELTA + 1);
     }
 
@@ -1244,7 +1244,7 @@ contract ForeignControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_zeroLiquidity() public {
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         foreignController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,
@@ -1257,7 +1257,7 @@ contract ForeignControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_liquidityTooHigh() public {
         vm.startPrank(ALM_RELAYER);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         foreignController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,

--- a/test/grove-mainnet-fork/4626Calls.t.sol
+++ b/test/grove-mainnet-fork/4626Calls.t.sol
@@ -91,7 +91,7 @@ contract MainnetControllerDepositERC4626FailureTests is SUSDSTestBase {
         vm.stopPrank();
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/exchange-rate-too-high");
+        vm.expectRevert("MC/exchange-rate-too-high");
         mainnetController.depositERC4626(address(susds), 5_000_000e18);
 
         vm.startPrank(Ethereum.GROVE_PROXY);
@@ -110,7 +110,7 @@ contract MainnetControllerDepositERC4626FailureTests is SUSDSTestBase {
         mainnetController.setMaxExchangeRate(address(susds), 0, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/exchange-rate-too-high");
+        vm.expectRevert("MC/exchange-rate-too-high");
         mainnetController.depositERC4626(address(susds), 5_000_000e18);
     }
 

--- a/test/grove-mainnet-fork/Aave.t.sol
+++ b/test/grove-mainnet-fork/Aave.t.sol
@@ -94,7 +94,7 @@ contract AaveV3MainMarketDepositFailureTests is AaveV3MainMarketBaseTest {
         mainnetController.setMaxSlippage(ATOKEN_USDS, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/max-slippage-not-set");
+        vm.expectRevert("MC/max-slippage-not-set");
         mainnetController.depositAave(ATOKEN_USDS, 1_000_000e18);
     }
 

--- a/test/grove-mainnet-fork/Centrifuge.t.sol
+++ b/test/grove-mainnet-fork/Centrifuge.t.sol
@@ -182,7 +182,7 @@ contract MainnetControllerClaimDepositERC7540FailureTests is CentrifugeTestBase 
 
     function test_claimDepositERC7540_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("MC/invalid-action");
         mainnetController.claimDepositERC7540(makeAddr("fake-vault"));
     }
 
@@ -331,7 +331,7 @@ contract MainnetControllerCancelCentrifugeDepositFailureTests is CentrifugeTestB
 
     function test_cancelCentrifugeDepositRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.cancelCentrifugeDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -387,7 +387,7 @@ contract MainnetControllerClaimCentrifugeCancelDepositFailureTests is Centrifuge
 
     function test_claimCentrifugeCancelDepositRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.claimCentrifugeCancelDepositRequest(makeAddr("fake-vault"));
     }
 
@@ -575,7 +575,7 @@ contract MainnetControllerClaimRedeemERC7540FailureTests is CentrifugeTestBase {
 
     function test_claimRedeemERC7540_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("MC/invalid-action");
         mainnetController.claimRedeemERC7540(makeAddr("fake-vault"));
     }
 
@@ -740,7 +740,7 @@ contract MainnetControllerCancelCentrifugeRedeemRequestFailureTests is Centrifug
 
     function test_cancelCentrifugeRedeemRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.cancelCentrifugeRedeemRequest(makeAddr("fake-vault"));
     }
 
@@ -800,7 +800,7 @@ contract MainnetControllerClaimCentrifugeCancelRedeemRequestFailureTests is Cent
 
     function test_claimCentrifugeCancelRedeemRequest_invalidVault() external {
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/invalid-action");
+        vm.expectRevert("CentrifugeLib/invalid-action");
         mainnetController.claimCentrifugeCancelRedeemRequest(makeAddr("fake-vault"));
     }
 

--- a/test/grove-mainnet-fork/CentrifugeV3.t.sol
+++ b/test/grove-mainnet-fork/CentrifugeV3.t.sol
@@ -117,7 +117,7 @@ contract MainnetControllerTransferSharesCentrifugeFailureTests is CentrifugeTest
         deal(relayer, 1 ether);  // Gas cost for Centrifuge
 
         vm.startPrank(relayer);
-        vm.expectRevert("MainnetController/centrifuge-id-not-configured");
+        vm.expectRevert("CentrifugeLib/id-not-configured");
         mainnetController.transferSharesCentrifuge{value: 0.1 ether}(
             CENTRIFUGE_VAULT,
             10_000_000e6,

--- a/test/grove-mainnet-fork/LayerZeroCalls.t.sol
+++ b/test/grove-mainnet-fork/LayerZeroCalls.t.sol
@@ -1,0 +1,705 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.8.0;
+
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+import {ERC20Mock} from "openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {Avalanche} from "grove-address-registry/Avalanche.sol";
+
+import {PSM3Deploy} from "spark-psm/deploy/PSM3Deploy.sol";
+import {IPSM3} from "spark-psm/src/PSM3.sol";
+import {MockRateProvider} from "spark-psm/test/mocks/MockRateProvider.sol";
+import {IRateProviderLike} from "spark-psm/src/interfaces/IRateProviderLike.sol";
+
+import {LZBridgeTesting} from "xchain-helpers/testing/bridges/LZBridgeTesting.sol";
+import {LZForwarder} from "xchain-helpers/forwarders/LZForwarder.sol";
+
+import {ForeignControllerDeploy} from "../../deploy/ControllerDeploy.sol";
+import {ControllerInstance} from "../../deploy/ControllerInstance.sol";
+
+import {ForeignControllerInit} from "../../deploy/ForeignControllerInit.sol";
+
+import {ALMProxy} from "../../src/ALMProxy.sol";
+import {ForeignController} from "../../src/ForeignController.sol";
+import {RateLimits} from "../../src/RateLimits.sol";
+import {RateLimitHelpers} from "../../src/RateLimitHelpers.sol";
+
+import {MyOFT} from "lib/devtools/examples/oft/contracts/MyOFT.sol";
+import {MyOFTAdapter} from "lib/devtools/examples/oft-adapter/contracts/MyOFTAdapter.sol";
+
+import "./ForkTestBase.t.sol";
+
+/**********************************************************************************************/
+/*** Abstract base: shared setUp for all LayerZero call tests                               ***/
+/**********************************************************************************************/
+
+abstract contract LayerZeroCallsTestBase is ForkTestBase {
+    using DomainHelpers for *;
+    using LZBridgeTesting for Bridge;
+
+    /**********************************************************************************************/
+    /*** Constants/state variables                                                              ***/
+    /**********************************************************************************************/
+
+    address pocket = makeAddr("pocket");
+
+    /**********************************************************************************************/
+    /*** ALM system deployments                                                                 ***/
+    /**********************************************************************************************/
+
+    ALMProxy          foreignAlmProxy;
+    RateLimits        foreignRateLimits;
+    ForeignController foreignController;
+
+    /**********************************************************************************************/
+    /*** Casted addresses for testing                                                           ***/
+    /**********************************************************************************************/
+
+    IERC20 usdsAvalanche;
+    IERC20 susdsAvalanche;
+
+    IPSM3 psmAvalanche;
+
+    uint32 constant sourceEndpointId      = 30101; // Ethereum EID
+    uint32 constant destinationEndpointId = 30106; // Avalanche EID
+
+    bytes32 sourceRateLimitKey;
+    bytes32 destinationRateLimitKey;
+
+    /**********************************************************************************************/
+    /*** Events                                                                                 ***/
+    /**********************************************************************************************/
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /**********************************************************************************************/
+    /*** Abstract hooks                                                                         ***/
+    /**********************************************************************************************/
+
+    function _getDestinationBlock() internal pure virtual returns (uint256);
+    function _setupDestinationTokens() internal virtual;
+    function _getDestinationToken() internal view virtual returns (address);
+    function _getDestinationOftAddress() internal view virtual returns (address);
+    function _setupSourceTokens() internal virtual;
+    function _getSourceOftAddress() internal view virtual returns (address);
+    function _afterSetUp() internal virtual {}
+    function _labelAddresses() internal virtual;
+
+    /**********************************************************************************************/
+    /*** Setup                                                                                  ***/
+    /**********************************************************************************************/
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        /**
+         * Step 1: Set up Avalanche environment **
+         */
+        destination = getChain("avalanche").createSelectFork(_getDestinationBlock());
+
+        usdsAvalanche  = IERC20(address(new ERC20Mock()));
+        susdsAvalanche = IERC20(address(new ERC20Mock()));
+
+        _setupDestinationTokens();
+
+        /**
+         * Step 2: Deploy and configure PSM with a pocket **
+         */
+        address destinationToken = _getDestinationToken();
+
+        MockRateProvider mockRateProvider = new MockRateProvider();
+        mockRateProvider.__setConversionRate(1.25e27);
+
+        IRateProviderLike rateProvider = IRateProviderLike(address(mockRateProvider));
+
+        deal(address(usdsAvalanche), address(this), 1e18); // For seeding PSM during deployment
+
+        psmAvalanche = IPSM3(
+            PSM3Deploy.deploy(
+                Avalanche.GROVE_EXECUTOR,
+                destinationToken,
+                address(usdsAvalanche),
+                address(susdsAvalanche),
+                address(rateProvider)
+            )
+        );
+
+        vm.prank(Avalanche.GROVE_EXECUTOR);
+        psmAvalanche.setPocket(pocket);
+
+        vm.prank(pocket);
+        IERC20(destinationToken).approve(address(psmAvalanche), type(uint256).max);
+
+        /**
+         * Step 3: Deploy and configure ALM system **
+         */
+        ControllerInstance memory controllerInst = ForeignControllerDeploy.deployFull({
+            admin                    : Avalanche.GROVE_EXECUTOR,
+            psm                      : address(psmAvalanche),
+            usdc                     : destinationToken,
+            cctp                     : address(0xDeadBeef), // unused
+            pendleRouter             : address(0xDeadBeef), // unused
+            uniswapV3Router          : address(0xDeadBeef), // unused
+            uniswapV3PositionManager : address(0xDeadBeef)  // unused
+        });
+
+        foreignAlmProxy   = ALMProxy(payable(controllerInst.almProxy));
+        foreignRateLimits = RateLimits(controllerInst.rateLimits);
+        foreignController = ForeignController(controllerInst.controller);
+
+        deal(address(foreignController), 100 ether); // LZ gas costs
+
+        address[] memory relayers = new address[](1);
+        relayers[0] = relayer;
+
+        ForeignControllerInit.ConfigAddressParams memory configAddresses =
+            ForeignControllerInit.ConfigAddressParams({freezer: freezer, relayers: relayers, oldController: address(0)});
+
+        ForeignControllerInit.CheckAddressParams memory checkAddresses = ForeignControllerInit.CheckAddressParams({
+            admin                    : Avalanche.GROVE_EXECUTOR,
+            psm                      : address(psmAvalanche),
+            cctp                     : address(0xDeadBeef), // unused
+            usdc                     : destinationToken,
+            pendleRouter             : address(0xDeadBeef), // unused
+            uniswapV3Router          : address(0xDeadBeef), // unused
+            uniswapV3PositionManager : address(0xDeadBeef)  // unused
+        });
+
+        ForeignControllerInit.MintRecipient[] memory mintRecipients = new ForeignControllerInit.MintRecipient[](1);
+
+        mintRecipients[0] = ForeignControllerInit.MintRecipient({
+            domain:        CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM,
+            mintRecipient: bytes32(uint256(uint160(address(almProxy))))
+        });
+
+        ForeignControllerInit.LayerZeroRecipient[] memory layerZeroRecipients =
+            new ForeignControllerInit.LayerZeroRecipient[](1);
+        layerZeroRecipients[0] = ForeignControllerInit.LayerZeroRecipient({
+            destinationEndpointId: LZForwarder.ENDPOINT_ID_ETHEREUM,
+            recipient:             bytes32(uint256(uint160(address(almProxy))))
+        });
+
+        ForeignControllerInit.CentrifugeRecipient[] memory centrifugeRecipients =
+            new ForeignControllerInit.CentrifugeRecipient[](0);
+
+        vm.startPrank(Avalanche.GROVE_EXECUTOR);
+
+        ForeignControllerInit.initAlmSystem(
+            controllerInst, configAddresses, checkAddresses, mintRecipients, layerZeroRecipients, centrifugeRecipients
+        );
+
+        destinationRateLimitKey = keccak256(
+            abi.encode(foreignController.LIMIT_LAYERZERO_TRANSFER(), _getDestinationOftAddress(), sourceEndpointId)
+        );
+
+        uint256 maxAmount = 5_000_000e18;
+        uint256 slope     = uint256(1_000_000e18) / 4 hours;
+
+        foreignRateLimits.setRateLimitData(destinationRateLimitKey, maxAmount, slope);
+        vm.stopPrank();
+
+        /**
+         * Step 4: Set up mainnet **
+         */
+        source.selectFork();
+
+        deal(address(mainnetController), 1 ether); // Gas cost for LZ
+
+        _setupSourceTokens();
+
+        bridge = LZBridgeTesting.createLZBridge(source, destination);
+
+        vm.startPrank(Ethereum.GROVE_PROXY);
+
+        sourceRateLimitKey = keccak256(
+            abi.encode(mainnetController.LIMIT_LAYERZERO_TRANSFER(), _getSourceOftAddress(), destinationEndpointId)
+        );
+
+        rateLimits.setRateLimitData(sourceRateLimitKey, maxAmount, slope);
+
+        // Add foreign ALM Proxy as recipient
+        mainnetController.setLayerZeroRecipient(
+            destinationEndpointId, bytes32(uint256(uint160(address(foreignAlmProxy))))
+        );
+
+        vm.stopPrank();
+
+        /**
+         * Step 5: Final setup and labels **
+         */
+        _afterSetUp();
+        _labelAddresses();
+    }
+}
+
+/**********************************************************************************************/
+/***                                                                                        ***/
+/***                        USDe tests (real forked OFTs with relay)                        ***/
+/***                                                                                        ***/
+/**********************************************************************************************/
+
+contract AvalancheChainUSDeToLayerZeroTestBase is LayerZeroCallsTestBase {
+    using DomainHelpers for *;
+    using LZBridgeTesting for Bridge;
+
+    /**********************************************************************************************/
+    /*** Avalanche addresses                                                                    ***/
+    /**********************************************************************************************/
+
+    // USDe OFT on Avalanche (ENAOFT - the OFT IS the token on Avalanche)
+    address constant USDE_OFT_AVALANCHE_ADDRESS = 0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34;
+
+    /**********************************************************************************************/
+    /*** Casted addresses for testing                                                           ***/
+    /**********************************************************************************************/
+
+    // Mainnet OFTs
+    IERC20 usdeOft;
+
+    // Avalanche Tokens
+    IERC20 usdeAvalanche;
+
+    uint256 USDE_AVALANCHE_SUPPLY;
+    uint256 USDE_MAINNET_BALANCE_BEFORE;
+
+    /**********************************************************************************************/
+    /*** Hook implementations                                                                   ***/
+    /**********************************************************************************************/
+
+    function _getDestinationBlock() internal pure override returns (uint256) {
+        return 82400000; // April 2026
+    }
+
+    function _setupDestinationTokens() internal override {
+        usdeAvalanche = IERC20(USDE_OFT_AVALANCHE_ADDRESS);
+        USDE_AVALANCHE_SUPPLY = usdeAvalanche.totalSupply();
+    }
+
+    function _getDestinationToken() internal view override returns (address) {
+        return address(usdeAvalanche);
+    }
+
+    function _getDestinationOftAddress() internal view override returns (address) {
+        return address(usdeAvalanche);
+    }
+
+    function _setupSourceTokens() internal override {
+        usdeOft = IERC20(0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34);
+    }
+
+    function _getSourceOftAddress() internal view override returns (address) {
+        return address(usdeOft);
+    }
+
+    function _afterSetUp() internal override {
+        USDE_MAINNET_BALANCE_BEFORE = usde.balanceOf(address(usdeOft));
+    }
+
+    function _labelAddresses() internal override {
+        vm.label(address(usdsAvalanche),     "usdsAvalanche");
+        vm.label(address(susdsAvalanche),    "susdsAvalanche");
+        vm.label(address(usdeAvalanche),     "usdeAvalanche");
+        vm.label(address(usdeOft),           "usdeOft");
+        vm.label(address(usde),              "usde");
+        vm.label(address(mainnetController), "mainnetController");
+        vm.label(address(foreignAlmProxy),   "foreignAlmProxy");
+        vm.label(address(foreignRateLimits), "foreignRateLimits");
+        vm.label(address(foreignController), "foreignController");
+        vm.label(address(rateLimits),        "rateLimits");
+        vm.label(address(almProxy),          "almProxy");
+    }
+}
+
+
+contract USDeToLayerZeroIntegrationTests is AvalancheChainUSDeToLayerZeroTestBase {
+    using DomainHelpers for *;
+    using LZBridgeTesting for Bridge;
+
+    event OFTSent(
+        bytes32 indexed guid, uint32 dstEid, address indexed fromAddress, uint256 amountSentLD, uint256 amountReceivedLD
+    );
+
+    function test_transferUSDeToLZ_sourceToDestination() external {
+        deal(address(usde), address(almProxy), 1e18);
+
+        assertEq(usde.balanceOf(address(almProxy)), 1e18, "ALM Proxy balance should be 1e18 before transfer");
+        assertEq(
+            usde.balanceOf(address(mainnetController)), 0, "Mainnet Controller balance should be 0 before transfer"
+        );
+        assertEq(
+            usde.balanceOf(address(usdeOft)), USDE_MAINNET_BALANCE_BEFORE, "OFT balance should match before transfer"
+        );
+
+        // approvalRequired == true: expect Approval from almProxy to OFT for USDe
+        vm.expectEmit(true, true, true, true, address(usde));
+        emit Approval(address(almProxy), address(usdeOft), 1e18);
+
+        _expectEthereumOftEmit(1e18);
+
+        vm.prank(relayer);
+        mainnetController.transferTokenLayerZero(address(usdeOft), 1e18, destinationEndpointId);
+
+        assertEq(usde.balanceOf(address(almProxy)), 0, "ALM Proxy balance should be 0 after transfer");
+        assertEq(usde.balanceOf(address(mainnetController)), 0, "Mainnet Controller balance should be 0 after transfer");
+        assertEq(
+            usde.balanceOf(address(usdeOft)),
+            USDE_MAINNET_BALANCE_BEFORE + 1e18,
+            "OFT balance should be increased by 1e18 after transfer"
+        );
+
+        destination.selectFork();
+
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignAlmProxy)),
+            0,
+            "Foreign ALM Proxy balance should be 0 before message relay"
+        );
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignController)),
+            0,
+            "Foreign Controller balance should be 0 before message relay"
+        );
+        assertEq(
+            usdeAvalanche.totalSupply(),
+            USDE_AVALANCHE_SUPPLY,
+            "Total supply should be USDE_AVALANCHE_SUPPLY before message relay"
+        );
+
+        bridge.relayMessagesToDestination(true, address(usdeOft), address(usdeAvalanche));
+
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignAlmProxy)),
+            1e18,
+            "Foreign ALM Proxy balance should be 1e18 after message relay"
+        );
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignController)),
+            0,
+            "Foreign Controller balance should be 0 after message relay"
+        );
+        assertEq(
+            usdeAvalanche.totalSupply(),
+            USDE_AVALANCHE_SUPPLY + 1e18,
+            "Total supply should be increased by 1e18 after message relay"
+        );
+    }
+
+
+    function test_transferUSDeToLZ_destinationToSource() external {
+        destination.selectFork();
+
+        deal(address(usdeAvalanche), address(foreignAlmProxy), 1e18, true);
+
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignAlmProxy)),
+            1e18,
+            "Foreign ALM Proxy balance should be 1e18 before transfer"
+        );
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignController)),
+            0,
+            "Foreign Controller balance should be 0 before transfer"
+        );
+        assertEq(
+            usdeAvalanche.totalSupply(), USDE_AVALANCHE_SUPPLY + 1e18, "Total supply should be USDE_AVALANCHE_SUPPLY + 1e18 before transfer"
+        );
+
+        // approvalRequired == false: no approval should be set
+        assertEq(
+            usdeAvalanche.allowance(address(foreignAlmProxy), address(usdeAvalanche)),
+            0,
+            "No allowance should exist before transfer (approvalRequired == false)"
+        );
+
+        _expectAvalancheOftEmit(1e18);
+
+        vm.prank(relayer);
+        foreignController.transferTokenLayerZero(address(usdeAvalanche), 1e18, sourceEndpointId);
+
+        // approvalRequired == false: allowance should still be zero (no approval was made)
+        assertEq(
+            usdeAvalanche.allowance(address(foreignAlmProxy), address(usdeAvalanche)),
+            0,
+            "No allowance should exist after transfer (approvalRequired == false)"
+        );
+
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignAlmProxy)), 0, "Foreign ALM Proxy balance should be 0 after transfer"
+        );
+        assertEq(
+            usdeAvalanche.balanceOf(address(foreignController)),
+            0,
+            "Foreign Controller balance should be 0 after transfer"
+        );
+        assertEq(
+            usdeAvalanche.totalSupply(),
+            USDE_AVALANCHE_SUPPLY,
+            "Total supply should be USDE_AVALANCHE_SUPPLY after transfer"
+        );
+
+        source.selectFork();
+
+        assertEq(usde.balanceOf(address(almProxy)), 0, "ALM Proxy balance should be 0 before relay");
+        assertEq(usde.balanceOf(address(mainnetController)), 0, "Mainnet Controller balance should be 0 before relay");
+        assertEq(
+            usde.balanceOf(address(usdeOft)),
+            USDE_MAINNET_BALANCE_BEFORE,
+            "OFT balance should be the same before relay"
+        );
+
+        bridge.relayMessagesToSource(true, address(usdeAvalanche), address(usdeOft));
+
+        assertEq(usde.balanceOf(address(almProxy)), 1e18, "ALM Proxy balance should be 1e18 after relay");
+        assertEq(usde.balanceOf(address(mainnetController)), 0, "Mainnet Controller balance should be 0 after relay");
+        assertEq(
+            usde.balanceOf(address(usdeOft)),
+            USDE_MAINNET_BALANCE_BEFORE - 1e18,
+            "OFT balance should be decreased by 1e18 after relay"
+        );
+    }
+
+    function _expectEthereumOftEmit(uint256 amount) internal {
+        vm.expectEmit(false, true, true, true, address(usdeOft));
+        emit OFTSent(bytes32(0), destinationEndpointId, address(almProxy), amount, amount);
+    }
+
+    function _expectAvalancheOftEmit(uint256 amount) internal {
+        vm.expectEmit(false, true, true, true, address(usdeAvalanche));
+        emit OFTSent(bytes32(0), sourceEndpointId, address(foreignAlmProxy), amount, amount);
+    }
+}
+
+/**********************************************************************************************/
+/***                                                                                        ***/
+/***       ETH/WETH tests (deployed MyOFT/MyOFTAdapter with full relay)                     ***/
+/***                                                                                        ***/
+/**********************************************************************************************/
+
+contract AvalancheChainETHToLayerZeroTestBase is LayerZeroCallsTestBase {
+    using DomainHelpers for *;
+    using LZBridgeTesting for Bridge;
+
+    /**********************************************************************************************/
+    /*** Avalanche addresses                                                                    ***/
+    /**********************************************************************************************/
+
+    // WETH.e on Avalanche
+    address constant WETH_AVALANCHE = 0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB;
+
+    /**********************************************************************************************/
+    /*** OFT deployments                                                                        ***/
+    /**********************************************************************************************/
+
+    // Source: MyOFT on mainnet (approvalRequired == false, burns/mints)
+    MyOFT oftMockMainnet;
+
+    // Destination: MyOFTAdapter wrapping WETH on Avalanche (approvalRequired == true, locks/unlocks)
+    MyOFTAdapter oftAdapterAvalanche;
+
+    /**********************************************************************************************/
+    /*** Casted addresses for testing                                                           ***/
+    /**********************************************************************************************/
+
+    IERC20 wethAvalanche;
+
+    uint256 WETH_ADAPTER_BALANCE;
+
+    /**********************************************************************************************/
+    /*** Hook implementations                                                                   ***/
+    /**********************************************************************************************/
+
+    function _getDestinationBlock() internal pure override returns (uint256) {
+        return 82400000; // April 2026
+    }
+
+    function _setupDestinationTokens() internal override {
+        wethAvalanche = IERC20(WETH_AVALANCHE);
+
+        // Deploy MyOFTAdapter wrapping WETH (approvalRequired == true)
+        oftAdapterAvalanche = new MyOFTAdapter(
+            address(wethAvalanche),
+            LZForwarder.ENDPOINT_AVALANCHE,
+            address(this)
+        );
+    }
+
+    function _getDestinationToken() internal view override returns (address) {
+        return address(wethAvalanche);
+    }
+
+    function _getDestinationOftAddress() internal view override returns (address) {
+        return address(oftAdapterAvalanche);
+    }
+
+    function _setupSourceTokens() internal override {
+        // Deploy MyOFT on mainnet (the OFT IS the token, approvalRequired == false)
+        oftMockMainnet = new MyOFT(
+            "Mock ETH OFT",
+            "mETH",
+            LZForwarder.ENDPOINT_ETHEREUM,
+            address(this)
+        );
+
+        // Configure peer: mainnet OFT -> Avalanche adapter
+        oftMockMainnet.setPeer(destinationEndpointId, bytes32(uint256(uint160(address(oftAdapterAvalanche)))));
+    }
+
+    function _getSourceOftAddress() internal view override returns (address) {
+        return address(oftMockMainnet);
+    }
+
+    function _afterSetUp() internal override {
+        // Configure peer: Avalanche adapter -> mainnet OFT
+        destination.selectFork();
+        oftAdapterAvalanche.setPeer(sourceEndpointId, bytes32(uint256(uint160(address(oftMockMainnet)))));
+
+        // Seed MyOFTAdapter with WETH (simulates prior bridge deposits for unlocking)
+        WETH_ADAPTER_BALANCE = 10_000_000e18;
+        deal(address(wethAvalanche), address(oftAdapterAvalanche), WETH_ADAPTER_BALANCE);
+
+        source.selectFork();
+    }
+
+    function _labelAddresses() internal override {
+        vm.label(address(oftMockMainnet),      "oftMockMainnet");
+        vm.label(address(oftAdapterAvalanche), "oftAdapterAvalanche");
+        vm.label(address(wethAvalanche),       "wethAvalanche");
+        vm.label(address(mainnetController),   "mainnetController");
+        vm.label(address(foreignAlmProxy),     "foreignAlmProxy");
+        vm.label(address(foreignRateLimits),   "foreignRateLimits");
+        vm.label(address(foreignController),   "foreignController");
+        vm.label(address(rateLimits),          "rateLimits");
+        vm.label(address(almProxy),            "almProxy");
+    }
+}
+
+/**********************************************************************************************/
+/*** Source to Destination tests (approvalRequired == false on MainnetController)            ***/
+/**********************************************************************************************/
+
+contract ETHToLayerZeroSourceToDestinationTests is AvalancheChainETHToLayerZeroTestBase {
+    using DomainHelpers for *;
+    using LZBridgeTesting for Bridge;
+
+    event OFTSent(
+        bytes32 indexed guid, uint32 dstEid, address indexed fromAddress, uint256 amountSentLD, uint256 amountReceivedLD
+    );
+
+    function test_transferETHToLZ_sourceToDestination() external {
+        deal(address(oftMockMainnet), address(almProxy), 2_900_000e18, true);
+
+        assertEq(
+            oftMockMainnet.balanceOf(address(almProxy)),
+            2_900_000e18,
+            "ALM Proxy balance should be 2_900_000e18 before transfer"
+        );
+        assertEq(oftMockMainnet.totalSupply(), 2_900_000e18, "OFT total supply should be 2_900_000e18 before transfer");
+
+        _expectEthereumOftEmit(2_900_000e18);
+
+        vm.prank(relayer);
+        mainnetController.transferTokenLayerZero(address(oftMockMainnet), 2_900_000e18, destinationEndpointId);
+
+        assertEq(oftMockMainnet.balanceOf(address(almProxy)), 0, "ALM Proxy balance should be 0 after transfer");
+        assertEq(oftMockMainnet.totalSupply(), 0, "OFT total supply should be 0 after transfer (burned)");
+
+        destination.selectFork();
+
+        assertEq(
+            wethAvalanche.balanceOf(address(foreignAlmProxy)),
+            0,
+            "Foreign ALM Proxy WETH balance should be 0 before message relay"
+        );
+
+        bridge.relayMessagesToDestination(true, address(oftMockMainnet), address(oftAdapterAvalanche));
+
+        assertEq(
+            wethAvalanche.balanceOf(address(foreignAlmProxy)),
+            2_900_000e18,
+            "Foreign ALM Proxy WETH balance should be 2_900_000e18 after message relay"
+        );
+        assertEq(
+            wethAvalanche.balanceOf(address(oftAdapterAvalanche)),
+            WETH_ADAPTER_BALANCE - 2_900_000e18,
+            "OFT Adapter WETH balance should decrease by 2_900_000e18 after message relay"
+        );
+    }
+
+    function _expectEthereumOftEmit(uint256 amount) internal {
+        vm.expectEmit(false, true, true, true, address(oftMockMainnet));
+        emit OFTSent(bytes32(0), destinationEndpointId, address(almProxy), amount, amount);
+    }
+}
+
+/**********************************************************************************************/
+/*** Destination to Source tests (approvalRequired == true on ForeignController)             ***/
+/**********************************************************************************************/
+
+contract ETHToLayerZeroDestinationToSourceTests is AvalancheChainETHToLayerZeroTestBase {
+    using DomainHelpers for *;
+    using LZBridgeTesting for Bridge;
+
+    event OFTSent(
+        bytes32 indexed guid, uint32 dstEid, address indexed fromAddress, uint256 amountSentLD, uint256 amountReceivedLD
+    );
+
+    function test_transferETHToLZ_destinationToSource() external {
+        destination.selectFork();
+
+        deal(address(wethAvalanche), address(foreignAlmProxy), 2_600_000e18);
+
+        assertEq(
+            wethAvalanche.balanceOf(address(foreignAlmProxy)),
+            2_600_000e18,
+            "Foreign ALM Proxy WETH balance should be 2_600_000e18 before transfer"
+        );
+        assertEq(
+            wethAvalanche.balanceOf(address(oftAdapterAvalanche)),
+            WETH_ADAPTER_BALANCE,
+            "OFT Adapter WETH balance should be WETH_ADAPTER_BALANCE before transfer"
+        );
+
+        // approvalRequired == true: expect Approval from foreignAlmProxy to adapter for WETH
+        vm.expectEmit(true, true, true, true, address(wethAvalanche));
+        emit Approval(address(foreignAlmProxy), address(oftAdapterAvalanche), 2_600_000e18);
+
+        _expectAvalancheOftEmit(2_600_000e18);
+
+        vm.prank(relayer);
+        foreignController.transferTokenLayerZero(address(oftAdapterAvalanche), 2_600_000e18, sourceEndpointId);
+
+        assertEq(
+            wethAvalanche.balanceOf(address(foreignAlmProxy)),
+            0,
+            "Foreign ALM Proxy WETH balance should be 0 after transfer"
+        );
+        assertEq(
+            wethAvalanche.balanceOf(address(oftAdapterAvalanche)),
+            WETH_ADAPTER_BALANCE + 2_600_000e18,
+            "OFT Adapter WETH balance should increase by 2_600_000e18 after transfer (locked)"
+        );
+
+        source.selectFork();
+
+        assertEq(oftMockMainnet.balanceOf(address(almProxy)), 0, "ALM Proxy balance should be 0 before relay");
+        assertEq(oftMockMainnet.totalSupply(), 0, "OFT total supply should be 0 before relay");
+
+        bridge.relayMessagesToSource(true, address(oftAdapterAvalanche), address(oftMockMainnet));
+
+        assertEq(
+            oftMockMainnet.balanceOf(address(almProxy)), 2_600_000e18, "ALM Proxy balance should be 2_600_000e18 after relay"
+        );
+        assertEq(
+            oftMockMainnet.balanceOf(address(mainnetController)), 0, "Mainnet Controller balance should be 0 after relay"
+        );
+        assertEq(
+            oftMockMainnet.totalSupply(), 2_600_000e18, "OFT total supply should be 2_600_000e18 after relay (minted)"
+        );
+    }
+
+    function _expectAvalancheOftEmit(uint256 amount) internal {
+        vm.expectEmit(false, true, true, true, address(oftAdapterAvalanche));
+        emit OFTSent(bytes32(0), sourceEndpointId, address(foreignAlmProxy), amount, amount);
+    }
+}

--- a/test/grove-mainnet-fork/UniswapV3.t.sol
+++ b/test/grove-mainnet-fork/UniswapV3.t.sol
@@ -191,19 +191,19 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
 
     function test_setUniswapV3PoolMaxTickDelta_isZero() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(_getPool(), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_isTooLarge() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(_getPool(), UniswapV3Lib.MAX_TICK_DELTA + 1);
     }
 
     function test_setUniswapV3AddLiquidityLowerTickBound_isTooSmall() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), MIN_UNISWAP_TICK - 1);
     }
 
@@ -213,7 +213,7 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
         int24 currentUpper = tickBounds.upper;
 
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(_getPool(), currentUpper);
     }
 
@@ -222,13 +222,13 @@ contract MainnetControllerConfigFailureTests is UniswapV3TestBase {
         int24 currentLower = tickBounds.lower;
 
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), currentLower);
     }
 
     function test_setUniswapV3AddLiquidityUpperTickBound_isTooLarge() public {
         vm.prank(GROVE_PROXY);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(_getPool(), MAX_UNISWAP_TICK + 1);
     }
 }
@@ -1617,7 +1617,7 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_zeroLiquidity() public {
         vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         mainnetController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,
@@ -1630,7 +1630,7 @@ contract MainnetControllerRemoveLiquidityFailureTests is UniswapV3TestBase {
 
     function test_removeLiquidityUniswapV3_liquidityTooHigh() public {
         vm.startPrank(relayer);
-        vm.expectRevert("UniswapV3Lib/liquidity-out-of-bounds");
+        vm.expectRevert("UniswapV3Lib/liquidity-oob");
         mainnetController.removeLiquidityUniswapV3(
             _getPool(),
             tokenId,

--- a/test/spark-base-fork/Aave.t.sol
+++ b/test/spark-base-fork/Aave.t.sol
@@ -74,7 +74,7 @@ contract AaveV3BaseMarketDepositFailureTests is AaveV3BaseMarketTestBase {
         foreignController.setMaxSlippage(ATOKEN_USDC, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("ForeignController/max-slippage-not-set");
+        vm.expectRevert("FC/max-slippage-not-set");
         foreignController.depositAave(ATOKEN_USDC, 1_000_000e6);
     }
 

--- a/test/spark-base-fork/Morpho.t.sol
+++ b/test/spark-base-fork/Morpho.t.sol
@@ -160,7 +160,7 @@ contract MorphoDepositFailureTests is MorphoBaseTest {
         vm.stopPrank();
 
         vm.prank(relayer);
-        vm.expectRevert("ForeignController/exchange-rate-too-high");
+        vm.expectRevert("FC/exchange-rate-too-high");
         foreignController.depositERC4626(MORPHO_VAULT_USDS, 25_000_000e18);
 
         vm.startPrank(Base.SPARK_EXECUTOR);
@@ -178,7 +178,7 @@ contract MorphoDepositFailureTests is MorphoBaseTest {
         foreignController.setMaxExchangeRate(MORPHO_VAULT_USDS, 0, 0);
 
         vm.prank(relayer);
-        vm.expectRevert("ForeignController/exchange-rate-too-high");
+        vm.expectRevert("FC/exchange-rate-too-high");
         foreignController.depositERC4626(MORPHO_VAULT_USDS, 1e18);
     }
 

--- a/test/spark-mainnet-fork/ERC4626DonationAttack.t.sol
+++ b/test/spark-mainnet-fork/ERC4626DonationAttack.t.sol
@@ -92,7 +92,7 @@ contract ERC4626DonationAttack is ERC4626DonationAttackTestBase {
         _doAttack();
 
         vm.prank(relayer);
-        vm.expectRevert("MainnetController/exchange-rate-too-high");
+        vm.expectRevert("MC/exchange-rate-too-high");
         mainnetController.depositERC4626(address(morphoVault), 2_000_000e18);
     }
 

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -183,7 +183,7 @@ contract MainnetControllerSetMaxSlippageTests is MainnetControllerAdminTestBase 
 
     function test_setMaxSlippage_outOfBounds() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/max-slippage-out-of-bounds");
+        vm.expectRevert("MC/max-slippage-oob");
         mainnetController.setMaxSlippage(makeAddr("pool"), 1e18 + 1);
     }
 }
@@ -209,13 +209,13 @@ contract MainnetControllerSetUniswapV3PoolMaxTickDeltaTests is MainnetController
 
     function test_setUniswapV3PoolMaxTickDelta_zeroMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_exceedsMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("MC/max-tick-delta-oob");
         mainnetController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 887273); // MAX_TICK_DELTA + 1
     }
 
@@ -265,7 +265,7 @@ contract MainnetControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Mainnet
 
     function test_setUniswapV3AddLiquidityLowerTickBound_belowMinTick() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -887273); // MIN_TICK - 1
     }
 
@@ -278,11 +278,11 @@ contract MainnetControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Mainnet
 
         // Try to set lower tick at or above the upper tick
         vm.prank(admin);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("MainnetController/lower-tick-out-of-bounds");
+        vm.expectRevert("MC/lower-tick-oob");
         mainnetController.setUniswapV3AddLiquidityLowerTickBound(pool, 1001);
     }
 
@@ -338,7 +338,7 @@ contract MainnetControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Mainnet
 
     function test_setUniswapV3AddLiquidityUpperTickBound_aboveMaxTick() public {
         vm.prank(admin);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 887273); // MAX_TICK + 1
     }
 
@@ -353,11 +353,11 @@ contract MainnetControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Mainnet
 
         // Try to set upper tick at or below the lower tick
         vm.prank(admin);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("MainnetController/upper-tick-out-of-bounds");
+        vm.expectRevert("MC/upper-tick-oob");
         mainnetController.setUniswapV3AddLiquidityUpperTickBound(pool, 999);
     }
 
@@ -411,10 +411,10 @@ contract MainnetControllerSetUniswapV3TwapSecondsAgoTests is MainnetControllerAd
     function test_setUniswapV3TwapSecondsAgo_outOfBounds() public {
         vm.startPrank(admin);
 
-        vm.expectRevert("MainnetController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("MC/twap-seconds-ago-oob");
         mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), uint32(type(int32).max));
 
-        vm.expectRevert("MainnetController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("MC/twap-seconds-ago-oob");
         mainnetController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), type(uint32).max);
 
         vm.stopPrank();
@@ -612,7 +612,7 @@ contract ForeignControllerSetMaxSlippageTests is ForeignControllerAdminTestBase 
 
     function test_setMaxSlippage_outOfBounds() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/max-slippage-out-of-bounds");
+        vm.expectRevert("FC/max-slippage-oob");
         foreignController.setMaxSlippage(makeAddr("pool"), 1e18 + 1);
     }
 }
@@ -638,13 +638,13 @@ contract ForeignControllerSetUniswapV3PoolMaxTickDeltaTests is ForeignController
 
     function test_setUniswapV3PoolMaxTickDelta_zeroMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 0);
     }
 
     function test_setUniswapV3PoolMaxTickDelta_exceedsMaxTickDelta() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/max-tick-delta-out-of-bounds");
+        vm.expectRevert("FC/max-tick-delta-oob");
         foreignController.setUniswapV3PoolMaxTickDelta(makeAddr("pool"), 887273); // MAX_TICK_DELTA + 1
     }
 
@@ -694,7 +694,7 @@ contract ForeignControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Foreign
 
     function test_setUniswapV3AddLiquidityLowerTickBound_belowMinTick() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(makeAddr("pool"), -887273); // MIN_TICK - 1
     }
 
@@ -707,11 +707,11 @@ contract ForeignControllerSetUniswapV3AddLiquidityLowerTickBoundTests is Foreign
 
         // Try to set lower tick at or above the upper tick
         vm.prank(admin);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("ForeignController/lower-tick-out-of-bounds");
+        vm.expectRevert("FC/lower-tick-oob");
         foreignController.setUniswapV3AddLiquidityLowerTickBound(pool, 1001);
     }
 
@@ -767,7 +767,7 @@ contract ForeignControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Foreign
 
     function test_setUniswapV3AddLiquidityUpperTickBound_aboveMaxTick() public {
         vm.prank(admin);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(makeAddr("pool"), 887273); // MAX_TICK + 1
     }
 
@@ -782,11 +782,11 @@ contract ForeignControllerSetUniswapV3AddLiquidityUpperTickBoundTests is Foreign
 
         // Try to set upper tick at or below the lower tick
         vm.prank(admin);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 1000);
 
         vm.prank(admin);
-        vm.expectRevert("ForeignController/upper-tick-out-of-bounds");
+        vm.expectRevert("FC/upper-tick-oob");
         foreignController.setUniswapV3AddLiquidityUpperTickBound(pool, 999);
     }
 
@@ -864,10 +864,10 @@ contract ForeignControllerSetUniswapV3TwapSecondsAgoTests is ForeignControllerAd
     function test_setUniswapV3TwapSecondsAgo_outOfBounds() public {
         vm.startPrank(admin);
 
-        vm.expectRevert("ForeignController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("FC/twap-seconds-ago-oob");
         foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), uint32(type(int32).max));
 
-        vm.expectRevert("ForeignController/twap-seconds-ago-out-of-bounds");
+        vm.expectRevert("FC/twap-seconds-ago-oob");
         foreignController.setUniswapV3TwapSecondsAgo(makeAddr("pool"), type(uint32).max);
 
         vm.stopPrank();


### PR DESCRIPTION
Re-bundles the post-v1.8.0 changes for v1.9.0 release.

## Included commits
- de54468 [GROVE-250] chore: shorten error strings (#100)
- 548c96f use centrifuge lib in foreign controller (#102)
- 36bf0fc refactor: use Centrifuge library in FC (#105)
- 6ee2638 test: add LZ tests (#107)